### PR TITLE
Whitelist Script for BEP12

### DIFF
--- a/BEP12.md
+++ b/BEP12.md
@@ -44,7 +44,7 @@ By default, all accounts’ flags are zero which means no script is specified. S
 
 Besides, the account flags changes will take effect since the next transaction.
 
-### Memo Check Script for Transfer
+### 0x1: Memo Check Script for Transfer
 This script is aimed to ensure the transfer transactions have valid memo if the receivers require this.
 
 Firstly, this script will check the following conditions:
@@ -71,6 +71,49 @@ if !isAllDigital(tx.memo) {
 return nil
 }
 ```
+
+### 0x2: Whitelisted Sender
+This script is used to ensure transfer transactions have valid recipients.
+The script will reject transfers to addresses that are not currently whitelisted.
+
+Firstly, this script will check the following conditions:
+
+- The transaction type is send.
+- The from address has flag 0x2
+
+Pseudocode:
+```
+func whitelistValidation(addr, tx) error {
+    if tx.Type != "send" {
+        return nil
+    }
+    if ! isSender(tx, addr) {
+        return nil
+    }
+    if ! isRecipientWhitelisted(addr, tx) {
+        return err("recipient not whitelisted")
+    }
+    return nil
+}
+```
+
+
+#### New Transaction: WhitelistRecipient
+Parameters for adding a whitelisted recipient
+
+|       | Type           | Description |
+|-------|----------------|-------------|
+| From  | sdk.AccAddress | Sender Address        |
+| To    | sdk.AccAddress | Whitelisted Recipient |
+
+
+#### New Transaction: UnwhitelistRecipient
+Parameters for removing a whitelisted recipient
+
+|       | Type           | Description |
+|-------|----------------|-------------|
+| From  | sdk.AccAddress | Sender Address        |
+| To    | sdk.AccAddress | Whitelisted Recipient |
 
 ### Scalability
 In the future, more scripts will be supported and existing scripts might need to be updated, so we must take scalability into consideration in the implementation.

--- a/BEP12.md
+++ b/BEP12.md
@@ -22,11 +22,12 @@ This BEP also proposes an important infrastructure for customized scripts. In th
 ### Add Flags into Address Structure
 ```
 type Account struct {
-  auth.BaseAccount                 `json:"base"`
-  Name                 string      `json:"name"`
-  FrozenCoins          sdk.Coins   `json:"frozen"`
-  LockedCoins          sdk.Coins   `json:"locked"`
-  Flags                uint64      `json:”flags”`
+  auth.BaseAccount                         `json:"base"`
+  Name                 string              `json:"name"`
+  FrozenCoins          sdk.Coins           `json:"frozen"`
+  LockedCoins          sdk.Coins           `json:"locked"`
+  Flags                uint64              `json:”flags”`
+  Whitelist            []sdk.AccAddress    `json:"whitelist"`
 }
 ```
 Each address represents an account. The account structure is shown as above. We will add a new field named “flags” into “Account”. Its data type is 64bit unsigned int. Each bit will represent a script, which means an account can specify at most 64 scripts. The flags of all existing accounts are zero. Users can send transactions to update their account flags.

--- a/BEP12.md
+++ b/BEP12.md
@@ -108,6 +108,10 @@ Parameters for adding whitelisted recipients:
 | From          | sdk.AccAddress   | Sender Address          |
 | Recipients    | sdk.AccAddress[] | Recipients to whitelist |
 
+
+The proposed fee is 0.00005, plus 0.00005 per recipient.
+This accounts for the increase in state size.
+
 #### New Transaction: UnwhitelistRecipients
 A node should reject the transaction if any of the accounts are not already whitelisted by this sender.
 
@@ -118,6 +122,8 @@ Parameters for removing whitelisted recipients:
 | From        | sdk.AccAddress   | Sender Address                   |
 | Recipients  | sdk.AccAddress[] | Whitelisted Recipients to remove |
 
+The proposed fee is 0.00005.
+There is not an additional fee per address to account for the freed state space.
 
 ### Scalability
 In the future, more scripts will be supported and existing scripts might need to be updated, so we must take scalability into consideration in the implementation.

--- a/BEP12.md
+++ b/BEP12.md
@@ -99,7 +99,9 @@ func whitelistValidation(addr, tx) error {
 
 
 #### New Transaction: WhitelistRecipients
-Parameters for adding whitelisted recipients
+A node should reject the transaction if any of the accounts are already whitelisted by this sender.
+
+Parameters for adding whitelisted recipients:
 
 |               | Type             | Description             |
 |---------------|------------------|-------------------------|
@@ -107,7 +109,9 @@ Parameters for adding whitelisted recipients
 | Recipients    | sdk.AccAddress[] | Recipients to whitelist |
 
 #### New Transaction: UnwhitelistRecipients
-Parameters for removing whitelisted recipients
+A node should reject the transaction if any of the accounts are not already whitelisted by this sender.
+
+Parameters for removing whitelisted recipients:
 
 |             | Type             | Description                      |
 |-------------|------------------|----------------------------------|

--- a/BEP12.md
+++ b/BEP12.md
@@ -98,22 +98,22 @@ func whitelistValidation(addr, tx) error {
 ```
 
 
-#### New Transaction: WhitelistRecipient
-Parameters for adding a whitelisted recipient
+#### New Transaction: WhitelistRecipients
+Parameters for adding whitelisted recipients
 
-|       | Type           | Description |
-|-------|----------------|-------------|
-| From  | sdk.AccAddress | Sender Address        |
-| To    | sdk.AccAddress | Whitelisted Recipient |
+|               | Type             | Description             |
+|---------------|------------------|-------------------------|
+| From          | sdk.AccAddress   | Sender Address          |
+| Recipients    | sdk.AccAddress[] | Recipients to whitelist |
 
+#### New Transaction: UnwhitelistRecipients
+Parameters for removing whitelisted recipients
 
-#### New Transaction: UnwhitelistRecipient
-Parameters for removing a whitelisted recipient
+|             | Type             | Description                      |
+|-------------|------------------|----------------------------------|
+| From        | sdk.AccAddress   | Sender Address                   |
+| Recipients  | sdk.AccAddress[] | Whitelisted Recipients to remove |
 
-|       | Type           | Description |
-|-------|----------------|-------------|
-| From  | sdk.AccAddress | Sender Address        |
-| To    | sdk.AccAddress | Whitelisted Recipient |
 
 ### Scalability
 In the future, more scripts will be supported and existing scripts might need to be updated, so we must take scalability into consideration in the implementation.

--- a/BEP12.md
+++ b/BEP12.md
@@ -27,7 +27,7 @@ type Account struct {
   FrozenCoins          sdk.Coins           `json:"frozen"`
   LockedCoins          sdk.Coins           `json:"locked"`
   Flags                uint64              `json:”flags”`
-  Whitelist            []sdk.AccAddress    `json:"whitelist"`
+  Whitelist            []sdk.AccAddress    `json:"recipients"`
 }
 ```
 Each address represents an account. The account structure is shown as above. We will add a new field named “flags” into “Account”. Its data type is 64bit unsigned int. Each bit will represent a script, which means an account can specify at most 64 scripts. The flags of all existing accounts are zero. Users can send transactions to update their account flags.


### PR DESCRIPTION

#### Changes
Transactions can send money to the wrong address, causing immediate loss of value.
A whitelist could be useful for a wallet or service to protect against mistake transfers, as an additional safeguard.
This also proposes transactions for adding to the whitelist or removing from it.
Reviewers @huangsuyu