### PR TITLE
Block incoming transactions script for BEP12

### DIFF
--- a/BEP12.md
+++ b/BEP12.md
@@ -85,12 +85,11 @@ if tx.Type != “send” {
 if ! isReceiver(tx, addr) {
    return nil
 }
-if  addr.flags.blockIncomingTxs == 1 {
-    return err(“account is not ready to accept MsgSend transaction”)
-}
-return nil
+return err(“account is not ready to accept MsgSend transaction”)
 }
 ```
+
+As a consequence, before setting this flag account owner should make sure to leave enough BNB tokens for covering fees for setting and unsetting this flag, otherwise, an account will stay in blocked state forever.
 
 ### Scalability
 In the future, more scripts will be supported and existing scripts might need to be updated, so we must take scalability into consideration in the implementation.

--- a/BEP12.md
+++ b/BEP12.md
@@ -72,6 +72,26 @@ return nil
 }
 ```
 
+### Blocking incoming transfer transactions
+The purpose of this script is to temporary block all incoming MsgSend transactions. This can be helpful in preventing users from sending tokens on the wrong/unmaintained account. 
+Accounts, that are used for providing some service based on transfers may use this script in order to temporary stop service.
+
+This is the pseudocode:
+```
+func incomingTxValidation(addr, tx) error {
+if tx.Type != “send” {
+    return nil
+}
+if ! isReceiver(tx, addr) {
+   return nil
+}
+if  addr.flags.blockIncomingTxs == 1 {
+    return err(“account is not ready to accept MsgSend transaction”)
+}
+return nil
+}
+```
+
 ### Scalability
 In the future, more scripts will be supported and existing scripts might need to be updated, so we must take scalability into consideration in the implementation.
 


### PR DESCRIPTION
**Changes**

Transactions can send money to addresses, which are not inspected by some person/service. This script can provide a way of temporary blocking all incoming transactions for the particular address.