### PR TITLE
New BEP to add SHA3-256 hashing and ECRecoverPublic key Precompiled contracts to BSC

### DIFF
--- a/BEP92.md
+++ b/BEP92.md
@@ -16,7 +16,7 @@ This BEP describes a proposal for Implementation of SHA3-256 as precompiled for 
 
 ## 2. Abstract
 
-BEP-92 Proposal describes a addition of implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key methods as precompiled native contracts
+BEP-92 Proposal describes an addition of implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key methods as precompiled native contracts
 
 ## 3. Status
 

--- a/BEP92.md
+++ b/BEP92.md
@@ -27,7 +27,7 @@ This BEP is a Work in Progress(WIP).
 This BEP proposing to enable more interoperability capablilities for Binance Smart Chain to verify sha3-256 based blockchains in the likes of ICON republic.
 
 - In order to validate the merkle tree data from blockchains which uses SHA3-256 hashing functions.
-- Used to recover & validate public key from signatures of validators.
+- Need these precompiles to recover & validate public key from signatures of validators.
 - Any blockchain using SHA3-256 FIPS 202 standard will need these preompiles interoperate with EVM based blockchains. Hence the need for both hashing & recover functions based on SHA3-256.
 
 ## 5. Specification
@@ -36,8 +36,8 @@ Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate bl
 
 ## 6. Gas
 
-SHA3-256 is in the same family as keccak256. Hence the gas price consumption for hash operation will be similar to existing Keccak operation.
-Hence,
+SHA3-256 is in the same family as keccak256. Hence, the gas price consumption for hash operation will be similar to existing Keccak operation.
+
 ```
 Gsha3 = 30 
 (Paid for each SHA3 operation.)

--- a/BEP92.md
+++ b/BEP92.md
@@ -24,7 +24,7 @@ This BEP is a Work in Progress(WIP).
 
 - In order to validate the merkle tree data from ICON and other similar blockchains, which uses the SHA3-256 hashing function. 
 - When the transaction hashes are created using the SHA3-256 hashing function and the same hashing mechanism is needed to validate signatures of validators in ICON. 
-- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. So the need for new ecrecoverPublicKey function as part of precompiled.
+- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. Hence the need for new ecrecoverPublicKey function as part of precompiled.
 
 ## 5. Specification
 Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate blocks, but most of the modern blockchains adapted SHA3-256,(slightly different padding rule) as part of [NIST FIPS 202](#https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).

--- a/BEP92.md
+++ b/BEP92.md
@@ -6,7 +6,9 @@
   - [3. Status](#3-status)
   - [4. Motivation](#4-motivation)
   - [5. Specification](#5-specification)
-  - [6. License](#6-license)
+  - [6. Gas Consumption](#6-gas)
+  - [7. Test Data](#7-testdata)
+  - [8. License](#6-license)
   
 ## 1. Summary
 
@@ -22,29 +24,49 @@ This BEP is a Work in Progress(WIP).
 
 ## 4. Motivation
 
-To bring more interoperability to Binance Smart Chain, this BEP proposing to add additional capabilities to verify sha3-256 based blockchains in the likes of ICON republic.
+This BEP proposing to enable more interoperability capablilities for Binance Smart Chain to verify sha3-256 based blockchains in the likes of ICON republic.
 
-- In order to validate the merkle tree data from ICON and other similar blockchains, which uses the SHA3-256 hashing function. 
-- When the transaction hashes are created using the SHA3-256 hashing function and the same hashing mechanism is needed to validate signatures of validators in ICON. 
-- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. Hence the need for new ecrecoverPublicKey function as part of precompiled.
+- In order to validate the merkle tree data from blockchains which uses SHA3-256 hashing functions.
+- Used to recover & validate public key from signatures of validators.
+- Any blockchain using SHA3-256 FIPS 202 standard will need these preompiles interoperate with EVM based blockchains. Hence the need for both hashing & recover functions based on SHA3-256.
 
 ## 5. Specification
+
 Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate blocks, but most of the modern blockchains adapted SHA3-256,(slightly different padding rule) as part of [NIST FIPS 202](#https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
+
+## 6. Gas
+
+SHA3-256 is in the same family as keccak256. Hence the gas price consumption for hash operation will be similar to existing Keccak operation.
+Hence,
+```
+Gsha3 = 30 
+(Paid for each SHA3 operation.)
+Gsha3word = 6 
+(Paid for each word (rounded up) for input data to a SHA3 operation)
+```
+Reference:
+[Ethereum:Yellow Paper](https://www.win.tue.nl/~mholende/seminar/references/ethereum_yellowpaper.pdf) - appendix G (Fee Schedule)
+
+## 7. TestData
 
 Test data to be used to validate the output of the proposed precompiled contract functions.
 
 sha3fips
 params
+```
 data : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’
 returns : ‘0xc7647f7e251bf1bd70863c8693e93a4e77dd0c9a689073e987d51254317dc704’
+```
 
 ecrecoverPublicKey
 params
+```
 hash : ‘0xc5d6c454e4d7a8e8a654f5ef96e8efe41d21a65b171b298925414aa3dc061e37’
 v : ‘0x00’
 r : ‘0x4011de30c04302a2352400df3d1459d6d8799580dceb259f45db1d99243a8d0c’
 s : ‘0x64f548b7776cb93e37579b830fc3efce41e12e0958cda9f8c5fcad682c610795’
 returns : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’
+```
 
 ## 6. License
 

--- a/BEP92.md
+++ b/BEP92.md
@@ -22,14 +22,14 @@ This BEP is a Work in Progress(WIP).
 
 ## 4. Motivation
 
+To bring more interoperability to Binance Smart Chain, this BEP proposing to add additional capabilities to verify sha3-256 based blockchains in the likes of ICON republic.
+
 - In order to validate the merkle tree data from ICON and other similar blockchains, which uses the SHA3-256 hashing function. 
 - When the transaction hashes are created using the SHA3-256 hashing function and the same hashing mechanism is needed to validate signatures of validators in ICON. 
 - Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. Hence the need for new ecrecoverPublicKey function as part of precompiled.
 
 ## 5. Specification
 Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate blocks, but most of the modern blockchains adapted SHA3-256,(slightly different padding rule) as part of [NIST FIPS 202](#https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
-
-To make it easier for other blockchains to interoperate with Binance smart chain, this BEP proposing to add the functionalities of SHA3-256 as part of precompiled native contracts.
 
 Test data to be used to validate the output of the proposed precompiled contract functions.
 

--- a/BEP92.md
+++ b/BEP92.md
@@ -1,6 +1,6 @@
-# BEP-92: Implementation of SHA3-256 FIPS 202 hash precompile and EcRecover Uncompressed public key precompile
+# BEP-92: Implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key precompiled contracts
 
-- [BEP-92: Implementation of SHA3-256 FIPS 202 hash precompile and EcRecover Uncompressed public key precompile](#bep-92)
+- [BEP-92: Implementation of SHA3-256 FIPS 202 hash precompiled and EcRecover Uncompressed public key precompiled](#bep-92)
   - [1. Summary](#1-summary)
   - [2. Abstract](#2-abstract)
   - [3. Status](#3-status)
@@ -10,11 +10,11 @@
   
 ## 1. Summary
 
-This BEP describes a proposal for Implementation of SHA3-256 as precompiles for BSC
+This BEP describes a proposal for Implementation of SHA3-256 as precompiled for BSC
 
 ## 2. Abstract
 
-BEP-92 Proposal describes a addition of implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key methods as precompile native contracts
+BEP-92 Proposal describes a addition of implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key methods as precompiled native contracts
 
 ## 3. Status
 
@@ -24,14 +24,14 @@ This BEP is a Work in Progress(WIP).
 
 - In order to validate the merkle tree data from ICON and other similar blockchains, which uses the SHA3-256 hashing function. 
 - When the transaction hashes are created using the SHA3-256 hashing function and the same hashing mechanism is needed to validate signatures of validators in ICON. 
-- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. So the need for new ecrecoverPublicKey function as part of precompiles.
+- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. So the need for new ecrecoverPublicKey function as part of precompiled.
 
 ## 5. Specification
 Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate blocks, but most of the modern blockchains adapted SHA3-256,(slightly different padding rule) as part of [NIST FIPS 202](#https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
 
 To make it easier for other blockchains to interoperate with Binance smart chain, this BEP proposing to add the functionalities of SHA3-256 as part of precompiled native contracts.
 
-Test data to be used to validate the output of the proposed precompile functions.
+Test data to be used to validate the output of the proposed precompiled contract functions.
 
 sha3fips
 params

--- a/BEP92.md
+++ b/BEP92.md
@@ -1,0 +1,51 @@
+# BEP-92: Implementation of SHA3-256 FIPS 202 hash precompile and EcRecover Uncompressed public key precompile
+
+- [BEP-92: Implementation of SHA3-256 FIPS 202 hash precompile and EcRecover Uncompressed public key precompile](#bep-92)
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Status](#3-status)
+  - [4. Motivation](#4-motivation)
+  - [5. Specification](#5-specification)
+  - [6. License](#6-license)
+  
+## 1. Summary
+
+This BEP describes a proposal for Implementation of SHA3-256 as precompiles for BSC
+
+## 2. Abstract
+
+BEP-92 Proposal describes a addition of implementation of SHA3-256 FIPS 202 hash and EcRecover Uncompressed public key methods as precompile native contracts
+
+## 3. Status
+
+This BEP is a Work in Progress(WIP). 
+
+## 4. Motivation
+
+- In order to validate the merkle tree data from ICON and other similar blockchains, which uses the SHA3-256 hashing function. 
+- When the transaction hashes are created using the SHA3-256 hashing function and the same hashing mechanism is needed to validate signatures of validators in ICON. 
+- Currently ICON uses a similar address building scheme to ethereum. ICON uses a part of the hash value of the public key, but with with SHA3-256 FIPS hashing function. So the need for new ecrecoverPublicKey function as part of precompiles.
+
+## 5. Specification
+Ethereum based virtual machines uses Keccak-256 hashing algorithm to evaulate blocks, but most of the modern blockchains adapted SHA3-256,(slightly different padding rule) as part of [NIST FIPS 202](#https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf).
+
+To make it easier for other blockchains to interoperate with Binance smart chain, this BEP proposing to add the functionalities of SHA3-256 as part of precompiled native contracts.
+
+Test data to be used to validate the output of the proposed precompile functions.
+
+sha3fips
+params
+data : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’
+returns : ‘0xc7647f7e251bf1bd70863c8693e93a4e77dd0c9a689073e987d51254317dc704’
+
+ecrecoverPublicKey
+params
+hash : ‘0xc5d6c454e4d7a8e8a654f5ef96e8efe41d21a65b171b298925414aa3dc061e37’
+v : ‘0x00’
+r : ‘0x4011de30c04302a2352400df3d1459d6d8799580dceb259f45db1d99243a8d0c’
+s : ‘0x64f548b7776cb93e37579b830fc3efce41e12e0958cda9f8c5fcad682c610795’
+returns : ‘0x0448250ebe88d77e0a12bcf530fe6a2cf1ac176945638d309b840d631940c93b78c2bd6d16f227a8877e3f1604cd75b9c5a8ab0cac95174a8a0a0f8ea9e4c10bca’
+
+## 6. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This is a new draft BEP to add new hashing sha3-256 hashing functionalities to BSC