### PR TITLE
BEP-151: Decommission Decentralized Exchange on BNB Beacon Chain

### DIFF
--- a/BEP151.md
+++ b/BEP151.md
@@ -4,8 +4,8 @@
 This BEP proposes to prune the DEX module from Beacon Chain.
 
 ## 2. Abstract
-Currently there is a high performance DEX running on Beacon Chain.
-After implementing this BEP, the DEX module will be disdisabled.
+Currently, there is a high performance DEX running on Beacon Chain.
+After implementing this BEP, the DEX module will be disabled.
 
 ## 3. Status
 This BEP is already implemented.

--- a/BEP151.md
+++ b/BEP151.md
@@ -4,7 +4,7 @@
 This BEP proposes to securely and smoothly decommission the build-in decentralized exchange on BNB Beacon Chain.
 
 ## 2. Abstract
-BNB Beacon Chain's primary focus, its native decentralized application ("dApp") BNB DEX, has demonstrated its low-latency matching with large capacity headroom. With the evolution of the framework, the high-speed DEX became a burden of the whole BNB ecosystem. After implementing this BEP, the DEX module will be disabled.
+BNB Beacon Chain’s primary focus, its native decentralized application ("dApp") BNB DEX, has demonstrated its low-latency matching with large capacity headroom. With the development of BNB Smart Chain and AMM-based decentralized exchanges running well on it, BNB DEX has less usage and liquidity. After implementing this BEP, the DEX module will be disabled, which will give Beacon Chain more computing power for the future computing and governance focuses.
 
 ## 3. Status
 Draft
@@ -17,48 +17,16 @@ Since BNB Smart Chain's(BSC) launch to mainnet in 2020, the AMM based decentrali
 Decommissioning the DEX module will reduce the need for system resources significantly for both validators and full nodes. The demand for liquidation can be fulfilled by BNB Smart Chain or the upcoming zkBAS.
 
 ## 5. Specification
-After the implementation of this BEP, transactions related to DEX(including `NewOrderMsg`, `ListMsg`, `ListMiniMsg`, etc) will return an error to disable listing new trading pairs or placing any new orders.
-All the existing orders will be canceled either by traders or by 3 days timeout. Thus there will be no more DEX transactions on Beacon Chain.
+After the implementation of this BEP, transactions related to DEX(including `NewOrderMsg`, `ListMsg`, `ListMiniMsg`) will return an error to disable listing new trading pairs or placing any new orders.
+All the existing orders will be canceled either by traders or by 3 days timeout(or 30 days for orders in the best 500 price levels, according to [BEP-67](https://github.com/bnb-chain/BEPs/blob/master/BEP67.md)). Thus there will be no more DEX transactions on Beacon Chain.
 
 ### 5.1 Safety
 After the implementation of this BEP, there will be no more new orders.
 The existing orders which are not matched yet will not be matched anymore.
-They can be canceled by the traders directly or by timeout automatically after 3 days, and refunded to the traders.
+They can be canceled by the traders directly or by timeout automatically after a period of time, and refunded to the traders.
 All the funds are SAFU.
 
 ### 5.2 Impact
-
-- For funds holders. It's recommended to refer to [this documentation](https://docs.bnbchain.org/docs/learn/cross-chain-transfer) to transfer existing tokens to BNB Smart Chain for more use scenarios.
-- For token owners. For tokens already issued on BNB Beacon Chain, It's recommended to transfer to BNB Smart Chain. For new token issue demand, it's recommended to issue on BNB Smart Chain directly.
-- For market makers. It's recommended to migrate to other DEXs on BNB Smart Chain. There is also an upcoming zkBAS which will provide an AMM DEX with high performance and low latency. Keep an eye on that.
-
-### 5.3 Decommission Plan
-
-1. Activate the hardfork.
-2. Wait for at least 1 week, confirm that there are no new orders and all existing orders are canceled.
-3. Decommission associated services.
-
-associated services list
-
-- DEX HTTP API. The RESTful service on the DEX module. Only the DEX related API will be decommissioned.
-  - [API reference](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/paths)
-  - endpoints
-    - ProdNetwork: <https://dex.binance.org>
-    - TestNetwork: <https://testnet-dex.binance.org>
-- WebSocket service
-  - [API reference](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/ws-connection)
-  - endpoints
-    - Mainnet: <wss://dex.binance.org/api/>
-    - Testnet: <wss://testnet-dex.binance.org/api/>
-- UI
-  - Mainnet
-    - https://www.bnbchain.world/en/trade/
-    - https://www.bnbchain.world/en/trade/mini
-  - Testnet
-    - https://testnet.binance.org/en/trade
-    - https://testnet.binance.org/en/trade/mini
-
-### 5.4 Others
 Transactions `MsgSubmitProposal` with type of `ProposalTypeListTradingPair` or `ProposalTypeDelistTradingPair` are used for submitting proposals to list new trading pairs or delist trading pairs.
 
 They might be not useful any longer but still valid after the BEP. It's not encouraged to send these transactions anymore.

--- a/BEP151.md
+++ b/BEP151.md
@@ -1,0 +1,23 @@
+# BEP-151: Prune DEX from Beacon Chain
+
+## 1. Summary
+This BEP proposes to prune the DEX module from Beacon Chain.
+
+## 2. Abstract
+Currently there is a high performance DEX running on Beacon Chain.
+After implementing this BEP, the DEX module will be disdisabled.
+
+## 3. Status
+This BEP is already implemented.
+
+## 4. Motivation
+The Beacon Chain will be more decentralized in the next stage. Prune the DEX module will reduce the need for system resources significantly for validators. The demand for DEX can be fulfilled by BNB Smart Chain or the upcoming zkBAS.
+
+## 5. Specification
+After the implementation of this BEP, the `NewOrderMsg` transaction will return an error to disable placing new orders.
+All the pending orders will be canceled by users or by timeout.
+Thus there will be no more DEX transactions on Beacon Chain.
+
+## 6. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEP151.md
+++ b/BEP151.md
@@ -1,23 +1,67 @@
-# BEP-151: Prune DEX from Beacon Chain
+# BEP-151: Decommission Decentralized Exchange on BNB Beacon Chain
 
 ## 1. Summary
-This BEP proposes to prune the DEX module from Beacon Chain.
+This BEP proposes to securely and smoothly decommission the build-in decentralized exchange on BNB Beacon Chain.
 
 ## 2. Abstract
-Currently, there is a high performance DEX running on Beacon Chain.
-After implementing this BEP, the DEX module will be disabled.
+BNB Beacon Chain's primary focus, its native decentralized application ("dApp") BNB DEX, has demonstrated its low-latency matching with large capacity headroom. With the evolution of the framework, the high-speed DEX became a burden of the whole BNB ecosystem. After implementing this BEP, the DEX module will be disabled.
 
 ## 3. Status
-This BEP is already implemented.
+Draft
 
 ## 4. Motivation
-The Beacon Chain will be more decentralized in the next stage. Prune the DEX module will reduce the need for system resources significantly for validators. The demand for DEX can be fulfilled by BNB Smart Chain or the upcoming zkBAS.
+BNB Beacon Chain(BC) is a blockchain developed by the BNB Chain community that implements a vision of a decentralized exchange (DEX) for digital assets. The heart of Beacon Chain is a highly performant matching engine built on distributed consensus that aims to replicate the < 1 second trading efficiency of current centralized exchanges.
+
+Since BNB Smart Chain's(BSC) launch to mainnet in 2020, the AMM based decentralized exchanges gain great success on BSC which even steal the thunder of order-book based DEX on BC. BC and BSC is a dual chain structure, with the evolution of this structure, BC plays more like a Beacon Chain that helps to enhance the security of BSC as a staking and governance layer. It is not suitable for a Beacon Chain to sustain a high-performance DEX any longer, especially when there is another DEX with massive adoption in the same ecosystem.
+
+Decommissioning the DEX module will reduce the need for system resources significantly for both validators and full nodes. The demand for liquidation can be fulfilled by BNB Smart Chain or the upcoming zkBAS.
 
 ## 5. Specification
-After the implementation of this BEP, the `NewOrderMsg` transaction will return an error to disable placing new orders.
-All the pending orders will be canceled by users or by timeout.
-Thus there will be no more DEX transactions on Beacon Chain.
+After the implementation of this BEP, transactions related to DEX(including `NewOrderMsg`, `ListMsg`, `ListMiniMsg`, etc) will return an error to disable listing new trading pairs or placing any new orders.
+All the existing orders will be canceled either by traders or by 3 days timeout. Thus there will be no more DEX transactions on Beacon Chain.
+
+### 5.1 Safety
+After the implementation of this BEP, there will be no more new orders.
+The existing orders which are not matched yet will not be matched anymore.
+They can be canceled by the traders directly or by timeout automatically after 3 days, and refunded to the traders.
+All the funds are SAFU.
+
+### 5.2 Impact
+
+- For funds holders. It's recommended to refer to [this documentation](https://docs.bnbchain.org/docs/learn/cross-chain-transfer) to transfer existing tokens to BNB Smart Chain for more use scenarios.
+- For token owners. For tokens already issued on BNB Beacon Chain, It's recommended to transfer to BNB Smart Chain. For new token issue demand, it's recommended to issue on BNB Smart Chain directly.
+- For market makers. It's recommended to migrate to other DEXs on BNB Smart Chain. There is also an upcoming zkBAS which will provide an AMM DEX with high performance and low latency. Keep an eye on that.
+
+### 5.3 Decommission Plan
+
+1. Activate the hardfork.
+2. Wait for at least 1 week, confirm that there are no new orders and all existing orders are canceled.
+3. Decommission associated services.
+
+associated services list
+
+- DEX HTTP API. The RESTful service on the DEX module. Only the DEX related API will be decommissioned.
+  - [API reference](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/paths)
+  - endpoints
+    - ProdNetwork: <https://dex.binance.org>
+    - TestNetwork: <https://testnet-dex.binance.org>
+- WebSocket service
+  - [API reference](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/ws-connection)
+  - endpoints
+    - Mainnet: <wss://dex.binance.org/api/>
+    - Testnet: <wss://testnet-dex.binance.org/api/>
+- UI
+  - Mainnet
+    - https://www.bnbchain.world/en/trade/
+    - https://www.bnbchain.world/en/trade/mini
+  - Testnet
+    - https://testnet.binance.org/en/trade
+    - https://testnet.binance.org/en/trade/mini
+
+### 5.3 Others
+Transactions `MsgSubmitProposal` with type of `ProposalTypeListTradingPair` or `ProposalTypeDelistTradingPair` are used for submitting proposals to list new trading pairs or delist trading pairs.
+
+They might be not useful any longer but still valid after the BEP. It's not encouraged to send these transactions anymore.
 
 ## 6. License
-
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEP151.md
+++ b/BEP151.md
@@ -58,7 +58,7 @@ associated services list
     - https://testnet.binance.org/en/trade
     - https://testnet.binance.org/en/trade/mini
 
-### 5.3 Others
+### 5.4 Others
 Transactions `MsgSubmitProposal` with type of `ProposalTypeListTradingPair` or `ProposalTypeDelistTradingPair` are used for submitting proposals to list new trading pairs or delist trading pairs.
 
 They might be not useful any longer but still valid after the BEP. It's not encouraged to send these transactions anymore.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ Here are the list of subjects of BEPs:
 * [BEP-127](BEP127.md): Temporary Maintenance Mode for Validators 
 * [BEP-128](BEP128.md): Improvement on BNB Smart Chain Staking Reward Distribution
 * [BEP-131](BEP131.md): Introduce candidate validators onto BNB Smart Chain
+* [BEP-151](BEP151.md): Decommission Decentralized Exchange on BNB Beacon Chain


### PR DESCRIPTION
# BEP-151: Decommission Decentralized Exchange on BNB Beacon Chain

## 1. Summary
This BEP proposes to securely and smoothly decommission the build-in decentralized exchange on BNB Beacon Chain.

## 2. Abstract
BNB Beacon Chain’s primary focus, its native decentralized application ("dApp") BNB DEX, has demonstrated its low-latency matching with large capacity headroom. With the development of BNB Smart Chain and AMM-based decentralized exchanges running well on it, BNB DEX has less usage and liquidity. After implementing this BEP, the DEX module will be disabled, which will give Beacon Chain more computing power for the future computing and governance focuses.

## 3. Status
Draft

## 4. Motivation
BNB Beacon Chain(BC) is a blockchain developed by the BNB Chain community that implements a vision of a decentralized exchange (DEX) for digital assets. The heart of Beacon Chain is a highly performant matching engine built on distributed consensus that aims to replicate the < 1 second trading efficiency of current centralized exchanges.

Since BNB Smart Chain's(BSC) launch to mainnet in 2020, the AMM based decentralized exchanges gain great success on BSC which even steal the thunder of order-book based DEX on BC. BC and BSC is a dual chain structure, with the evolution of this structure, BC plays more like a Beacon Chain that helps to enhance the security of BSC as a staking and governance layer. It is not suitable for a Beacon Chain to sustain a high-performance DEX any longer, especially when there is another DEX with massive adoption in the same ecosystem.

Decommissioning the DEX module will reduce the need for system resources significantly for both validators and full nodes. The demand for liquidation can be fulfilled by BNB Smart Chain or the upcoming zkBAS.

## 5. Specification
After the implementation of this BEP, transactions related to DEX(including `NewOrderMsg`, `ListMsg`, `ListMiniMsg`) will return an error to disable listing new trading pairs or placing any new orders.
All the existing orders will be canceled either by traders or by 3 days timeout(or 30 days for orders in the best 500 price levels, according to [BEP-67](https://github.com/bnb-chain/BEPs/blob/master/BEP67.md)). Thus there will be no more DEX transactions on Beacon Chain.

### 5.1 Safety
After the implementation of this BEP, there will be no more new orders.
The existing orders which are not matched yet will not be matched anymore.
They can be canceled by the traders directly or by timeout automatically after a period of time, and refunded to the traders.
All the funds are SAFU.

### 5.2 Impact
Transactions `MsgSubmitProposal` with type of `ProposalTypeListTradingPair` or `ProposalTypeDelistTradingPair` are used for submitting proposals to list new trading pairs or delist trading pairs.

They might be not useful any longer but still valid after the BEP. It's not encouraged to send these transactions anymore.

## 6. License
The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
