### PR TITLE
[WIP] BEP-176: Validator Reward Model 2.0

### DIFF
--- a/BEP176.md
+++ b/BEP176.md
@@ -1,0 +1,61 @@
+# BEP-176: Validator Reward Model 2.0
+
+- [BEP-176: Validator Reward Model 2.0](#bep-176-validator-reward-model-20)
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Status](#3-status)
+  - [4.Motivation](#4motivation)
+  - [5. Specification](#5-specification)
+    - [5.1 Mechanism \& Governance](#51-mechanism--governance)
+  - [6. License](#6-license)
+
+
+## 1. Summary
+
+This BEP will introduce a new validator reward model on BNB Smart Chain. As a result of this BEP, the validator staking reward policy is going to be modified such that it is more accurately representative of the validator's contribution to the overall network.
+
+## 2. Abstract
+
+The mechanism for validator income distribution will be altered when this BEP is implemented. The specifics are still being worked out, but in general, we may divide the overall rewards from gas fees into two parts:
+- Network Verification Reward: will be distributed among all validators more equitably, according to their contributions to the whole network.
+- Block Reward: The single producer for its work on this block.
+
+The proportion of each part is up for debate, and validators will have the possibility to alter the value through governance.
+
+The idea suggests that we may favor a slightly greater ratio of the Network Verification Reward vs Block Rewards, given that the primary objective is to validate the network to enable real and secure transactions. Our viewpoint is that transactions are resources shared among validators; a validator should not consider them to be their property.
+
+## 3. Status
+
+Draft
+
+## 4.Motivation
+Before this BEP, the validator’s reward mostly relied on the transaction gas fee it received, as their only source of rewards is the gas fee for the transaction in the blocks they produce. A validator will get more rewards if it packs more transactions into the block it produces. It was designed to encourage validators to add more transactions, but it didn’t represent the overall contribution that a validator made. In general opinion, a validator should be rewarded even if it only produces empty blocks, because it helps build the network, e.g. verify blocks, keep a copy of the latest network storage state, broadcast blocks and transactions…
+
+The fact that some validators may try to utilize an excessive amount of time to include more transactions into their own block in order to increase their revenue makes the situation even more precarious. It is unethical toward the other validators, and it would also lead to the instability of the network.
+
+The rewards logic will serve multiple objectives. In addition to transaction inclusion, it is necessary to consider efforts to validate blocks and maintain network security.
+
+Absolute fairness is not an easy goal to accomplish, but we do our best to bring about some improvements with this BEP. We name it Validator Reward Model 2.0, it could have further revisions to keep improving it.
+
+## 5. Specification
+Currently, as defined by the Parlia consensus, block producers will collect the gas fee of each transaction as its reward and distribute it to a system contract temporarily.
+The system contract will forward the reward information to Beacon Chain periodically to settle the reward along with the staking information kept on Beacon Chain.
+
+The general procedure will not be changed in this BEP, but 2 steps will be added:
+- For each block, part of the block reward will be put into the shared network contribution funding pool. Initially, the ratio is set to 50%, i.e. half of the rewards will be shared with the other validators.
+- Before the system contracts forward the reward information to Beacon Chain, the funding pool will be distributed according to the network contribution of each validator. The contribution could be simply determined by the block number it produces.
+
+### 5.1 Mechanism & Governance
+
+A governable parameters: **validatorRewardRatio** will be introduced in the ValidatorSet Contract. At the end of each block, the Validator will sign a transaction to invoke the deposit function of the contract to transfer the gas fee. The validator reward model logic is implemented within the deposit function that: **validatorRewardRatio * ( gasFee - burnRatio*gasFee)**  will be transferred to the validator contribution funding pool address;
+
+The initial setting:
+- validatorRewardRatio = 50%
+
+This process will be carried on BNB Beacon Chain, every community member can propose a change of the params. The proposal needs to receive a minimum deposit of BNB (2000BNB on mainnet for now, refundable after the proposal has passed) so that the validators can vote for it. The validators of BSC can vote for it or against it based on their staking amount of BNB.
+
+If the total voting power of bounded validators that votes for it reaches the quorum (50% on mainnet), the proposal will pass and the corresponding change of the params will be passed onto BSC via cross-chain communication and take effect immediately. The vote of unbounded validators will not be considered into the tally.
+
+## 6. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEP176.md
+++ b/BEP176.md
@@ -29,9 +29,7 @@ The idea suggests that we may favor a slightly greater ratio of the Network Veri
 Draft
 
 ## 4.Motivation
-Before this BEP, the validator’s reward mostly relied on the transaction gas fee it received, as their only source of rewards is the gas fee for the transaction in the blocks they produce. A validator will get more rewards if it packs more transactions into the block it produces. It was designed to encourage validators to add more transactions, but it didn’t represent the overall contribution that a validator made. In general opinion, a validator should be rewarded even if it only produces empty blocks, because it helps build the network, e.g. verify blocks, keep a copy of the latest network storage state, broadcast blocks and transactions…
-
-The fact that some validators may try to utilize an excessive amount of time to include more transactions into their own block in order to increase their revenue makes the situation even more precarious. It is unethical toward the other validators, and it would also lead to the instability of the network.
+Before this BEP, the validator’s reward mostly relied on the transaction gas fee it received, as their only source of rewards is the gas fee for the transaction in the blocks they produce. A validator will get more rewards if it packs more transactions into the block it produces. It was designed to encourage validators to add more transactions, but it didn’t represent the overall contribution that a validator made. In general opinion, a validator should be rewarded even if it only produces empty blocks, because it helps build the network, e.g. verify blocks, keep a copy of the latest network storage state, broadcast blocks and transactions… But validator will lose its dedicated block reward if it produces empty block, so it still encourages validator to add more transactions in its block.
 
 The rewards logic will serve multiple objectives. In addition to transaction inclusion, it is necessary to consider efforts to validate blocks and maintain network security.
 


### PR DESCRIPTION
# BEP-176: Validator Reward Model 2.0

- [BEP-176: Validator Reward Model 2.0](#bep-176-validator-reward-model-20)
  - [1. Summary](#1-summary)
  - [2. Abstract](#2-abstract)
  - [3. Status](#3-status)
  - [4.Motivation](#4motivation)
  - [5. Specification](#5-specification)
    - [5.1 Mechanism \& Governance](#51-mechanism--governance)
  - [6. License](#6-license)


## 1. Summary

This BEP will introduce a new validator reward model on BNB Smart Chain. As a result of this BEP, the validator staking reward policy is going to be modified such that it is more accurately representative of the validator's contribution to the overall network.

## 2. Abstract

The mechanism for validator income distribution will be altered when this BEP is implemented. The specifics are still being worked out, but in general, we may divide the overall rewards from gas fees into two parts:
- Network Verification Reward: will be distributed among all validators more equitably, according to their contributions to the whole network.
- Block Reward: The single producer for its work on this block.

The proportion of each part is up for debate, and validators will have the possibility to alter the value through governance.

The idea suggests that we may favor a slightly greater ratio of the Network Verification Reward vs Block Rewards, given that the primary objective is to validate the network to enable real and secure transactions. Our viewpoint is that transactions are resources shared among validators; a validator should not consider them to be their property.

## 3. Status

Draft

## 4.Motivation
Before this BEP, the validator’s reward mostly relied on the transaction gas fee it received, as their only source of rewards is the gas fee for the transaction in the blocks they produce. A validator will get more rewards if it packs more transactions into the block it produces. It was designed to encourage validators to add more transactions, but it didn’t represent the overall contribution that a validator made. In general opinion, a validator should be rewarded even if it only produces empty blocks, because it helps build the network, e.g. verify blocks, keep a copy of the latest network storage state, broadcast blocks and transactions… But validator will lose its dedicated block reward if it produces empty block, so it still encourages validator to add more transactions in its block.

The rewards logic will serve multiple objectives. In addition to transaction inclusion, it is necessary to consider efforts to validate blocks and maintain network security.

Absolute fairness is not an easy goal to accomplish, but we do our best to bring about some improvements with this BEP. We name it Validator Reward Model 2.0, it could have further revisions to keep improving it.

## 5. Specification
Currently, as defined by the Parlia consensus, block producers will collect the gas fee of each transaction as its reward and distribute it to a system contract temporarily.
The system contract will forward the reward information to Beacon Chain periodically to settle the reward along with the staking information kept on Beacon Chain.

The general procedure will not be changed in this BEP, but 2 steps will be added:
- For each block, part of the block reward will be put into the shared network contribution funding pool. Initially, the ratio is set to 50%, i.e. half of the rewards will be shared with the other validators.
- Before the system contracts forward the reward information to Beacon Chain, the funding pool will be distributed according to the network contribution of each validator. The contribution could be simply determined by the block number it produces.

### 5.1 Mechanism & Governance

A governable parameters: **validatorRewardRatio** will be introduced in the ValidatorSet Contract. At the end of each block, the Validator will sign a transaction to invoke the deposit function of the contract to transfer the gas fee. The validator reward model logic is implemented within the deposit function that: **validatorRewardRatio * ( gasFee - burnRatio*gasFee)**  will be transferred to the validator contribution funding pool address;

The initial setting:
- validatorRewardRatio = 50%

This process will be carried on BNB Beacon Chain, every community member can propose a change of the params. The proposal needs to receive a minimum deposit of BNB (2000BNB on mainnet for now, refundable after the proposal has passed) so that the validators can vote for it. The validators of BSC can vote for it or against it based on their staking amount of BNB.

If the total voting power of bounded validators that votes for it reaches the quorum (50% on mainnet), the proposal will pass and the corresponding change of the params will be passed onto BSC via cross-chain communication and take effect immediately. The vote of unbounded validators will not be considered into the tally.

## 6. License

The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
