### PR TITLE
 BEP-126: revert the chain liveness to ½*v+ from ⅔*v+

### DIFF
--- a/BEP126.md
+++ b/BEP126.md
@@ -109,8 +109,7 @@ The new longest chain rule can be described as follows.
 In the current Parlia consensus, the validator liveness is ½*v+1=11, which means when there are more than 11 validators
 online, the chain can get increased continuously.
 
-In this design, we should change the liveness from ½*v+1=11 to ⅔*v=14, this can protect the chain from getting increased
-in a malicious fork.
+In this design, the liveness of producing blocks and the liveness of finalizing blocks are independent. Despite of ⅔*v+ validators are needed to keep the finalized block number increasing, keeping the chain increasing only need ½*v+ validators as before.
 
 ### 4.2 Theory Proof
 Assume the malicious validators are less than ⅓*v, honest validators are more than ⅔*v, honest validators always behave


### PR DESCRIPTION
The liveness of producing blocks and the liveness of finalizing blocks are independent.
Revert the chain liveness to ½*v+ from ⅔*v+.