### PR TITLE
BEP-213: EIP-1559 with base fee of 0

### DIFF
--- a/BEP213.md
+++ b/BEP213.md
@@ -1,14 +1,3 @@
----
-eip: 1559
-title: Fee market change for ETH 1.0 chain
-author: Vitalik Buterin (@vbuterin), Eric Conner (@econoar), Rick Dudley (@AFDudley), Matthew Slipper (@mslipper), Ian Norden (@i-norden), Abdelhamid Bakhta (@abdelhamidbakhta)
-discussions-to: https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783
-status: Final
-type: Standards Track
-category: Core
-created: 2019-04-13
-requires: 2718, 2930
----
 
 # BEP-214: Enable EIP-1559 with base fee of 0
 

--- a/BEP213.md
+++ b/BEP213.md
@@ -1,0 +1,39 @@
+---
+eip: 1559
+title: Fee market change for ETH 1.0 chain
+author: Vitalik Buterin (@vbuterin), Eric Conner (@econoar), Rick Dudley (@AFDudley), Matthew Slipper (@mslipper), Ian Norden (@i-norden), Abdelhamid Bakhta (@abdelhamidbakhta)
+discussions-to: https://ethereum-magicians.org/t/eip-1559-fee-market-change-for-eth-1-0-chain/2783
+status: Final
+type: Standards Track
+category: Core
+created: 2019-04-13
+requires: 2718, 2930
+---
+
+# BEP-214: Enable EIP-1559 with base fee of 0
+
+
+## Summary
+This BEP introduces [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) headers and transactions to BSC but with base fee set to 0. 
+
+
+## Status
+This BEP is a draft. The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.
+
+## Motivation
+To keep up to date with the latest developments in EVM blockchains it is important to keep the block and transaction structures up to date. New features (such as account abstraction) being introduced
+to EVM chains already presuppose EIP-1559 type of block headers and transactions. Therefore, for compatibility reasons it is important that EIP-1559 constructs be enabled on BSC. 
+
+EIP-1559 was introduced in Ethereum to improve the gas fee pricing mechanism and to make the ETH token more deflationary, as the base fee would be burnt after a transaction was completed. In BSC there is already a burning mechanism in place ([BEP-95](https://github.com/bnb-chain/BEPs/blob/master/BEP95.md)) so there is no need to burn the base fee. Therefore the base fee will be set to 0, and will
+not adjust based on network congestion like in the Ethereum EIP.
+
+Essentially the same gas fee mechanism will be in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0 `maxPriorityFeePerGas = maxFeePerGas` .
+
+
+
+## Backwards Compatibility
+Legacy transactions will still work and be included in blocks.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`. 
+
+
+## Copyright
+Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION


# BEP-214: Enable EIP-1559 with base fee of 0


## Summary
This BEP introduces [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) headers and transactions to BSC but with base fee set to 0. 


## Status
This BEP is a draft. The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.

## Motivation
To keep up to date with the latest developments in EVM blockchains it is important to keep the block and transaction structures up to date. New features (such as account abstraction) being introduced
to EVM chains already presuppose EIP-1559 type of block headers and transactions. Therefore, for compatibility reasons it is important that EIP-1559 constructs be enabled on BSC. 

EIP-1559 was introduced in Ethereum to improve the gas fee pricing mechanism and to make the ETH token more deflationary, as the base fee would be burnt after a transaction was completed. In BSC there is already a burning mechanism in place ([BEP-95](https://github.com/bnb-chain/BEPs/blob/master/BEP95.md)) so there is no need to burn the base fee. Therefore the base fee will be set to 0, and will
not adjust based on network congestion like in the Ethereum EIP.

Essentially the same gas fee mechanism will be in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0 `maxPriorityFeePerGas = maxFeePerGas` .



## Backwards Compatibility
Legacy transactions will still work and be included in blocks.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`. 


## Copyright
Copyright and related rights waived via [CC0](../LICENSE.md).