### PR TITLE
BEP-214: BASEFEE opcode

### DIFF
--- a/BEP214.md
+++ b/BEP214.md
@@ -1,0 +1,54 @@
+# BEP-214: Basefee opcode
+
+
+
+## Summary
+Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-213 (EIP-1559 with base fee of 0).
+
+## Abstract
+
+Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.
+
+Status
+This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 for BSC network configurations and perform hard fork.
+
+## Rationale
+The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-213)).
+
+## Specification
+Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
+
+|  Op  	| Input 	| Output 	| Cost 	|
+|:----:	|:-----:	|:------:	|:----:	|
+| 0x48 	|   0   	|    1   	|   2  	|
+
+## Rationale
+
+### Gas cost
+The value of the base fee is needed to process transactions. That means it's value is already available before running the EVM code.
+The opcode does not add extra complexity and additional read/write operations, hence the choice of `G_base` gas cost.
+
+## Backwards Compatibility
+There are no known backward compatibility issues with this opcode.
+
+## Test Cases
+
+### Nominal case
+Assuming current block base fee is `7 wei`.
+This should push the value `7` (left padded byte32) to the stack.
+
+Bytecode: `0x4800` (`BASEFEE, STOP`)
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |    BASEFEE  |    2 |        [] |        [] |
+|    1  |    STOP     |    0 |       [7] |        [] |
+
+Output: 0x
+Consumed gas: `2`
+
+## Security Considerations
+The value of the base fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.
+
+## Copyright
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
# BEP-214: BASEFEE opcode



## Summary
Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-213 (EIP-1559 with base fee of 0).

## Abstract

Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.

Status
This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 for BSC network configurations and perform hard fork.

## Rationale
The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-213)).

## Specification
Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.

|  Op  	| Input 	| Output 	| Cost 	|
|:----:	|:-----:	|:------:	|:----:	|
| 0x48 	|   0   	|    1   	|   2  	|

## Rationale

### Gas cost
The value of the base fee is needed to process transactions. That means it's value is already available before running the EVM code.
The opcode does not add extra complexity and additional read/write operations, hence the choice of `G_base` gas cost.

## Backwards Compatibility
There are no known backward compatibility issues with this opcode.

## Test Cases

### Nominal case
Assuming current block base fee is `7 wei`.
This should push the value `7` (left padded byte32) to the stack.

Bytecode: `0x4800` (`BASEFEE, STOP`)

|  Pc   |      Op     | Cost |   Stack   |   RStack  |
|-------|-------------|------|-----------|-----------|
|    0  |    BASEFEE  |    2 |        [] |        [] |
|    1  |    STOP     |    0 |       [7] |        [] |

Output: 0x
Consumed gas: `2`

## Security Considerations
The value of the base fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.

## Copyright
The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).