### PR TITLE
BEP-226: Implement EIP-1559 with base fee of 0

### DIFF
--- a/BEP226.md
+++ b/BEP226.md
@@ -1,0 +1,28 @@
+
+# BEP-226: Enable EIP-1559 with base fee of 0
+
+
+## Summary
+This BEP introduces [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) headers and transactions to BSC but with base fee set to 0. 
+
+
+## Status
+This BEP is a draft. The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.
+
+## Motivation
+To keep up to date with the latest developments in EVM blockchains it is important to keep the block and transaction structures up to date. New features (such as account abstraction) being introduced
+to EVM chains already presuppose EIP-1559 type of block headers and transactions. Therefore, for compatibility reasons it is important that EIP-1559 constructs be enabled on BSC. 
+
+EIP-1559 was introduced in Ethereum to improve the gas fee pricing mechanism and to make the ETH token more deflationary, as the base fee would be burnt after a transaction was completed. In BSC there is already a burning mechanism in place ([BEP-95](https://github.com/bnb-chain/BEPs/blob/master/BEP95.md)) so there is no need to burn the base fee. Therefore the base fee will be set to 0, and will
+not adjust based on network congestion like in the Ethereum EIP.
+
+Essentially the same gas fee mechanism will be in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0, `maxPriorityFeePerGas = maxFeePerGas` .
+
+
+
+## Backwards Compatibility
+Legacy transactions will still work and be included in blocks.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`. 
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEP226.md
+++ b/BEP226.md
@@ -1,28 +1,45 @@
+<pre>
+    BEP: 226
+    Title: Enable EIP-1559 with base fee of 0
+    Status: Pre-Draft
+    Type: Standards
+    Created: 2023-04-17
+</pre>
 
 # BEP-226: Enable EIP-1559 with base fee of 0
 
+- [BEP-226: Enable EIP-1559 with base fee of 0](#bep-226-enable-eip-1559-with-base-fee-of-0)
+  - [1. Summary](#1-summary)
+  - [2. Motivation](#2-motivation)
+  - [3. Specification](#3-specification)
+  - [4. Backwards Compatibility](#4-backwards-compatibility)
+  - [5. License](#5-license)
 
-## Summary
+
+
+## 1. Summary
 This BEP introduces [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) headers and transactions to BSC but with base fee set to 0. 
 
 
-## Status
-This BEP is a draft. The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.
-
-## Motivation
+##  2. Motivation
 To keep up to date with the latest developments in EVM blockchains it is important to keep the block and transaction structures up to date. New features (such as account abstraction) being introduced
 to EVM chains already presuppose EIP-1559 type of block headers and transactions. Therefore, for compatibility reasons it is important that EIP-1559 constructs be enabled on BSC. 
 
 EIP-1559 was introduced in Ethereum to improve the gas fee pricing mechanism and to make the ETH token more deflationary, as the base fee would be burnt after a transaction was completed. In BSC there is already a burning mechanism in place ([BEP-95](https://github.com/bnb-chain/BEPs/blob/master/BEP95.md)) so there is no need to burn the base fee. Therefore the base fee will be set to 0, and will
 not adjust based on network congestion like in the Ethereum EIP.
 
-Essentially the same gas fee mechanism will be in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0, `maxPriorityFeePerGas = maxFeePerGas` .
+
+## 3. Specification
+
+Essentially the same gas fee mechanism will be kept in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0, `maxPriorityFeePerGas = maxFeePerGas` .
 
 
+The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0, and disable extra checks that keep track of the gas utilization over time ) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.
 
-## Backwards Compatibility
+
+## 4. Backwards Compatibility
 Legacy transactions will still work and be included in blocks.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`. 
 
 
-## Copyright
+## 5. License
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
<pre>
    BEP: 226
    Title: Enable EIP-1559 with base fee of 0
    Status: Pre-Draft
    Type: Standards
    Created: 2023-04-17
</pre>

# BEP-226: Enable EIP-1559 with base fee of 0

- [BEP-226: Enable EIP-1559 with base fee of 0](#bep-226-enable-eip-1559-with-base-fee-of-0)
  - [1. Summary](#1-summary)
  - [2. Motivation](#2-motivation)
  - [3. Specification](#3-specification)
  - [4. Backwards Compatibility](#4-backwards-compatibility)
  - [5. License](#5-license)



## 1. Summary
This BEP introduces [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) headers and transactions to BSC but with base fee set to 0. 


##  2. Motivation
To keep up to date with the latest developments in EVM blockchains it is important to keep the block and transaction structures up to date. New features (such as account abstraction) being introduced
to EVM chains already presuppose EIP-1559 type of block headers and transactions. Therefore, for compatibility reasons it is important that EIP-1559 constructs be enabled on BSC. 

EIP-1559 was introduced in Ethereum to improve the gas fee pricing mechanism and to make the ETH token more deflationary, as the base fee would be burnt after a transaction was completed. In BSC there is already a burning mechanism in place ([BEP-95](https://github.com/bnb-chain/BEPs/blob/master/BEP95.md)) so there is no need to burn the base fee. Therefore the base fee will be set to 0, and will
not adjust based on network congestion like in the Ethereum EIP.


## 3. Specification

Essentially the same gas fee mechanism will be kept in place but the extra `BaseFee` field will be enabled in the header (which will be required to be 0). In addition, the `GasTipCap` (a.k.a. `maxPriorityFeePerGas`)  and  `maxFeePerGas` fields will be enabled by using a dynamic transaction type instead of the legacy transaction types. Since `baseFee` will be 0, `maxPriorityFeePerGas = maxFeePerGas` .


The code for EIP-1559 has already been merged from upstream go-ethereum codebase into BSC node codebase, but some custom modifications are still needed (to maintain a constant base fee of 0, and disable extra checks that keep track of the gas utilization over time ) and to ensure everything works correctly before a hard fork enabling this BEP on BSC network.


## 4. Backwards Compatibility
Legacy transactions will still work and be included in blocks.  This is due to the fact that upgrading from legacy transactions to new transactions results in the legacy transaction's `gas_price ` entirely being consumed either by the `base_fee_per_gas` and the `priority_fee_per_gas`. 


## 5. License
Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).