### PR TITLE
BEP-227: Implement EIP-3198: BASEFEE opcode

### DIFF
--- a/BEP227.md
+++ b/BEP227.md
@@ -1,0 +1,54 @@
+# BEP-227: BASEFEE opcode
+
+
+
+## Summary
+Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-226 (EIP-1559 with base fee of 0).
+
+## Abstract
+
+Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.
+
+Status
+This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 for BSC network configurations and perform hard fork.
+
+## Rationale
+The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-213)).
+
+## Specification
+Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
+
+|  Op  	| Input 	| Output 	| Cost 	|
+|:----:	|:-----:	|:------:	|:----:	|
+| 0x48 	|   0   	|    1   	|   2  	|
+
+## Rationale
+
+### Gas cost
+The value of the base fee is needed to process transactions. That means it's value is already available before running the EVM code.
+The opcode does not add extra complexity and additional read/write operations, hence the choice of `G_base` gas cost.
+
+## Backwards Compatibility
+There are no known backward compatibility issues with this opcode.
+
+## Test Cases
+
+### Nominal case
+Assuming current block base fee is `7 wei`.
+This should push the value `7` (left padded byte32) to the stack.
+
+Bytecode: `0x4800` (`BASEFEE, STOP`)
+
+|  Pc   |      Op     | Cost |   Stack   |   RStack  |
+|-------|-------------|------|-----------|-----------|
+|    0  |    BASEFEE  |    2 |        [] |        [] |
+|    1  |    STOP     |    0 |       [7] |        [] |
+
+Output: 0x
+Consumed gas: `2`
+
+## Security Considerations
+The value of the base fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.
+
+## Copyright
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEP227.md
+++ b/BEP227.md
@@ -3,17 +3,17 @@
 
 
 ## Summary
-Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-226 (EIP-1559 with base fee of 0).
+Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-226 (EIP-1559 with base fee of 0). 
 
 ## Abstract
 
 Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.
 
-Status
-This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 for BSC network configurations and perform hard fork.
+## Status
+This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 (this BEP) for BSC network configurations and perform hard fork.
 
 ## Rationale
-The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-213)).
+The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-226)).
 
 ## Specification
 Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.

--- a/BEP227.md
+++ b/BEP227.md
@@ -1,39 +1,62 @@
-# BEP-227: BASEFEE opcode
+<pre>
+    BEP: 227
+    Title: Add BASEFEE opcode
+    Status: Pre-Draft
+    Type: Standards
+    Created: 2023-04-17
+</pre>
 
 
 
-## Summary
+# BEP-227: Add BASEFEE opcode
+
+- [BEP-227: Add BASEFEE opcode](#bep-227-add-basefee-opcode)
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Motivation](#3-motivation)
+  - [4. Specification](#4-specification)
+    - [5. Gas cost](#5-gas-cost)
+  - [6. Backwards Compatibility](#6-backwards-compatibility)
+  - [7. Test Cases](#7-test-cases)
+    - [7.1 Nominal case](#71-nominal-case)
+  - [8. Security Considerations](#8-security-considerations)
+  - [9. License](#9-license)
+
+
+
+## 1. Summary
 Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-226 (EIP-1559 with base fee of 0). 
 
-## Abstract
+## 2. Abstract
 
 Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.
 
-## Status
-This BEP is a draft. The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 (this BEP) for BSC network configurations and perform hard fork.
+The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 (this BEP) for BSC network configurations and performing a hard fork.
 
-## Rationale
+
+## 3. Motivation
 The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-226)).
 
-## Specification
+## 4. Specification
 Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.
 
 |  Op  	| Input 	| Output 	| Cost 	|
 |:----:	|:-----:	|:------:	|:----:	|
 | 0x48 	|   0   	|    1   	|   2  	|
 
-## Rationale
 
-### Gas cost
+
+
+### 5. Gas cost
 The value of the base fee is needed to process transactions. That means it's value is already available before running the EVM code.
 The opcode does not add extra complexity and additional read/write operations, hence the choice of `G_base` gas cost.
 
-## Backwards Compatibility
+## 6. Backwards Compatibility
 There are no known backward compatibility issues with this opcode.
 
-## Test Cases
+## 7. Test Cases
 
-### Nominal case
+### 7.1 Nominal case
 Assuming current block base fee is `7 wei`.
 This should push the value `7` (left padded byte32) to the stack.
 
@@ -47,8 +70,8 @@ Bytecode: `0x4800` (`BASEFEE, STOP`)
 Output: 0x
 Consumed gas: `2`
 
-## Security Considerations
+## 8. Security Considerations
 The value of the base fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.
 
-## Copyright
+## 9. License
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
<pre>
    BEP: 227
    Title: Add BASEFEE opcode
    Status: Pre-Draft
    Type: Standards
    Created: 2023-04-17
</pre>



# BEP-227: Add BASEFEE opcode

- [BEP-227: Add BASEFEE opcode](#bep-227-add-basefee-opcode)
  - [1. Summary](#1-summary)
  - [2. Abstract](#2-abstract)
  - [3. Motivation](#3-motivation)
  - [4. Specification](#4-specification)
    - [5. Gas cost](#5-gas-cost)
  - [6. Backwards Compatibility](#6-backwards-compatibility)
  - [7. Test Cases](#7-test-cases)
    - [7.1 Nominal case](#71-nominal-case)
  - [8. Security Considerations](#8-security-considerations)
  - [9. License](#9-license)



## 1. Summary
Adds an opcode that gives the EVM access to the block's base fee. This BEP is dependent on BEP-226 (EIP-1559 with base fee of 0). 

## 2. Abstract

Add a `BASEFEE (0x48)` that returns the value of the base fee of the current block it is executing in.

The code for this BEP has already been merged from upstream go-ethereum codebase into BSC node codebase. The work entails enabling EIP-3198 (this BEP) for BSC network configurations and performing a hard fork.


## 3. Motivation
The intended use case would be for contracts to get the value of the base fee (introduced by EIP-1559 (BEP-226)).

## 4. Specification
Add a `BASEFEE` opcode at `(0x48)`, with gas cost `G_base`.

|  Op  	| Input 	| Output 	| Cost 	|
|:----:	|:-----:	|:------:	|:----:	|
| 0x48 	|   0   	|    1   	|   2  	|




### 5. Gas cost
The value of the base fee is needed to process transactions. That means it's value is already available before running the EVM code.
The opcode does not add extra complexity and additional read/write operations, hence the choice of `G_base` gas cost.

## 6. Backwards Compatibility
There are no known backward compatibility issues with this opcode.

## 7. Test Cases

### 7.1 Nominal case
Assuming current block base fee is `7 wei`.
This should push the value `7` (left padded byte32) to the stack.

Bytecode: `0x4800` (`BASEFEE, STOP`)

|  Pc   |      Op     | Cost |   Stack   |   RStack  |
|-------|-------------|------|-----------|-----------|
|    0  |    BASEFEE  |    2 |        [] |        [] |
|    1  |    STOP     |    0 |       [7] |        [] |

Output: 0x
Consumed gas: `2`

## 8. Security Considerations
The value of the base fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.

## 9. License
The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).