### PR TITLE
Update BEP171.md

### DIFF
--- a/BEP171.md
+++ b/BEP171.md
@@ -40,7 +40,7 @@ ICS23 attempts to define a generic, cross-language, binary representation of mer
 
 ### 3.2 Timelock
 If the value of the cross chain transfer is larger than a predefined threshold, the funds will be locked in [TokenHub](https://bscscan.com/address/0x0000000000000000000000000000000000001004) for a fixed period before they can be withdrawn to the target account.
-The default threshold of BNB is 10K, and the default lock period is 6 hours,  both of them are governable. However, it is hard to set a proper threshold for other BEP20 tokens. We will grant the token [owner](https://github.com/bnb-chain/BEPs/blob/master/BEP20.md#5116-getowner) permission to decide a proper threshold. The interface to set transfer threshold is as follows:
+The default threshold of BNB is 10K, and the default lock period is 12 hours,  both of them are governable. However, it is hard to set a proper threshold for other BEP20 tokens. We will grant the token [owner](https://github.com/bnb-chain/BEPs/blob/master/BEP20.md#5116-getowner) permission to decide a proper threshold. The interface to set transfer threshold is as follows:
 
 	function setLargeTransferLimit(address bep20Token, uint256 largeTransferLimit) external onlyTokenOwner(bep20Token);
 


### PR DESCRIPTION
## Description

Update the lock period to 12 hours for large bnb cross-chain transfer as recommended by the security team to ensure the community has adequate response time to ensure cross-chain security