### PR TITLE
BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT

### DIFF
--- a/BEPs/BEP-312.md
+++ b/BEPs/BEP-312.md
@@ -1,0 +1,58 @@
+<pre>
+  BEP: 312
+  Title: Announce EIP-6049: Deprecate SELFDESTRUCT
+  Status: Draft
+  Type: Standards
+  Created: 2023-10-30
+</pre>
+
+# BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT
+
+- [BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT](#bep-312-announce-eip-6049-deprecate-selfdestruct)
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Motivation](#3-motivation)
+  - [4. Specification](#4-specification)
+  - [5. Rationale](#5-rationale)
+  - [6. Backwards Compatibility](#6-backwards-compatibility)
+  - [7. Security Considerations](#7-security-considerations)
+  - [8. License](#8-license)
+  - [9. Reference](#9-reference)
+
+
+## 1. Summary
+As part of Shanghai upgrade, EIP-6049: Deprecate SELFDESTRUCT is required to be announced in the BSC community.
+
+## 2. Abstract
+
+This EIP deprecates the `SELFDESTRUCT` opcode and warns against its use. A breaking change to this functionality is likely to come in the future.
+
+## 3. Motivation
+
+Discussions about how to change `SELFDESTRUCT` are ongoing. But there is a strong consensus that *something* will change.
+
+## 4. Specification
+
+Documentation of the `SELFDESTRUCT` opcode is updated to warn against its use and to note that a breaking change may be forthcoming.
+
+## 5. Rationale
+
+As time goes on, the cost of doing something increases, because any change to `SELFDESTRUCT` will be a breaking change.
+
+The Ethereum Blog and other official sources have not provided any warning to developers about a potential forthcoming change.
+
+## 6. Backwards Compatibility
+
+This EIP updates non-normative text in the Yellow Paper. No changes to clients is applicable.
+
+## 7. Security Considerations
+
+None.
+
+## 8. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## 9. Reference
+
+William Entriken (@fulldecent), "EIP-6049: Deprecate SELFDESTRUCT," Ethereum Improvement Proposals, no. 6049, November 2022. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-6049.


### PR DESCRIPTION
<pre>
  BEP: 312
  Title: Announce EIP-6049: Deprecate SELFDESTRUCT
  Status: Draft
  Type: Standards
  Created: 2023-10-30
</pre>

# BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT

- [BEP-312: Announce EIP-6049 Deprecate SELFDESTRUCT](#bep-312-announce-eip-6049-deprecate-selfdestruct)
  - [1. Summary](#1-summary)
  - [2. Abstract](#2-abstract)
  - [3. Motivation](#3-motivation)
  - [4. Specification](#4-specification)
  - [5. Rationale](#5-rationale)
  - [6. Backwards Compatibility](#6-backwards-compatibility)
  - [7. Security Considerations](#7-security-considerations)
  - [8. License](#8-license)
  - [9. Reference](#9-reference)


## 1. Summary
As part of Shanghai upgrade, EIP-6049: Deprecate SELFDESTRUCT is required to be announced in the BSC community.

## 2. Abstract

This EIP deprecates the `SELFDESTRUCT` opcode and warns against its use. A breaking change to this functionality is likely to come in the future.

## 3. Motivation

Discussions about how to change `SELFDESTRUCT` are ongoing. But there is a strong consensus that *something* will change.

## 4. Specification

Documentation of the `SELFDESTRUCT` opcode is updated to warn against its use and to note that a breaking change may be forthcoming.

## 5. Rationale

As time goes on, the cost of doing something increases, because any change to `SELFDESTRUCT` will be a breaking change.

The Ethereum Blog and other official sources have not provided any warning to developers about a potential forthcoming change.

## 6. Backwards Compatibility

This EIP updates non-normative text in the Yellow Paper. No changes to clients is applicable.

## 7. Security Considerations

None.

## 8. License

The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

## 9. Reference

William Entriken (@fulldecent), "EIP-6049: Deprecate SELFDESTRUCT," Ethereum Improvement Proposals, no. 6049, November 2022. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-6049.