### PR TITLE
BEP-345: Implement EIP-7516: BLOBBASEFEE opcode

### DIFF
--- a/BEPs/BEP-345.md
+++ b/BEPs/BEP-345.md
@@ -1,0 +1,69 @@
+<pre>
+  BEP: 345
+  Title: Implement EIP-7516: BLOBBASEFEE opcode
+  Status: Draft
+  Type: Standards
+  Created: 2024-01-15
+</pre>
+
+
+# BEP-345: Implement EIP-7516: BLOBBASEFEE opcode
+
+- [BEP-345: Implement EIP-7516: BLOBBASEFEE opcode](#bep-345-implement-eip-7516-blobbasefee-opcode)
+  - [1. Summary](#1-summary)
+  - [2. Abstract](#2-abstract)
+  - [3. Motivation](#3-motivation)
+  - [4. Specification](#4-specification)
+  - [5. Rationale](#5-rationale)
+  - [6. Backwards Compatibility](#6-backwards-compatibility)
+  - [7. Security Considerations](#7-security-considerations)
+  - [8. License](#8-license)
+  - [9. Reference](#9-reference)
+
+
+## 1. Summary
+As part of Cancun upgrade, EIP-7516: BLOBBASEFEE opcode is required to be implemented to BSC.
+
+## 2. Abstract
+
+Add a `BLOBBASEFEE (0x4a)` that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./BEP227.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./BEP-336.md).
+
+## 3. Motivation
+
+The intended use case would be for contracts to get the value of the blob base-fee. This feature enables blob-data users to programmatically account for the blob gas price, eg:
+
+- Allow rollup contracts to trustlessly account for blob data usage costs.
+- Blob gas futures can be implemented based on it which allows for blob users to smooth out data blob costs.
+
+## 4. Specification
+
+Add a `BLOBBASEFEE` opcode at `(0x4a)`, with gas cost `2`.
+
+| Op   | Input | Output | Cost |
+|------|-------|--------|------|
+| 0x4a | 0     | 1      | 2    |
+
+`BLOBBASEFEE` returns the result of the `get_blob_gasprice(header) -> int` function as defined in [EIP-4844 §Gas accounting](./BEP-336.md#gas-accounting).
+
+## 5. Rationale
+
+### Gas cost
+
+The value of the blob base-fee is needed to process data-blob transactions. That means its value is already available before running the EVM code.
+The opcode does not add extra complexity and additional read/write operations, hence the choice of `2` gas cost. This is also identical to [EIP-3198](./BEP227.md) (`BASEFEE` opcode)'s cost as it just makes available data that is in the header.
+
+## 6. Backwards Compatibility
+
+There are no known backward compatibility issues with this opcode.
+
+## 7. Security Considerations
+
+The value of the blob base-fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.
+
+## 8. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+## 9. Reference
+
+Carl Beekhuizen (@carlbeek), "EIP-7516: BLOBBASEFEE opcode [DRAFT]," Ethereum Improvement Proposals, no. 7516, September 2023. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-7516.


### PR DESCRIPTION
<pre>
  BEP: 345
  Title: Implement EIP-7516: BLOBBASEFEE opcode
  Status: Draft
  Type: Standards
  Created: 2024-01-15
</pre>


# BEP-345: Implement EIP-7516: BLOBBASEFEE opcode

- [BEP-345: Implement EIP-7516: BLOBBASEFEE opcode](#bep-345-implement-eip-7516-blobbasefee-opcode)
  - [1. Summary](#1-summary)
  - [2. Abstract](#2-abstract)
  - [3. Motivation](#3-motivation)
  - [4. Specification](#4-specification)
  - [5. Rationale](#5-rationale)
  - [6. Backwards Compatibility](#6-backwards-compatibility)
  - [7. Security Considerations](#7-security-considerations)
  - [8. License](#8-license)
  - [9. Reference](#9-reference)


## 1. Summary
As part of Cancun upgrade, EIP-7516: BLOBBASEFEE opcode is required to be implemented to BSC.

## 2. Abstract

Add a `BLOBBASEFEE (0x4a)` that returns the value of the blob base-fee of the current block it is executing in. It is the identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode) except that it returns the blob base-fee as per [EIP-4844](./eip-4844.md).

## 3. Motivation

The intended use case would be for contracts to get the value of the blob base-fee. This feature enables blob-data users to programmatically account for the blob gas price, eg:

- Allow rollup contracts to trustlessly account for blob data usage costs.
- Blob gas futures can be implemented based on it which allows for blob users to smooth out data blob costs.

## 4. Specification

Add a `BLOBBASEFEE` opcode at `(0x4a)`, with gas cost `2`.

| Op   | Input | Output | Cost |
|------|-------|--------|------|
| 0x4a | 0     | 1      | 2    |

`BLOBBASEFEE` returns the result of the `get_blob_gasprice(header) -> int` function as defined in [EIP-4844 §Gas accounting](./eip-4844.md#gas-accounting).

## 5. Rationale

### Gas cost

The value of the blob base-fee is needed to process data-blob transactions. That means its value is already available before running the EVM code.
The opcode does not add extra complexity and additional read/write operations, hence the choice of `2` gas cost. This is also identical to [EIP-3198](./eip-3198.md) (`BASEFEE` opcode)'s cost as it just makes available data that is in the header.

## 6. Backwards Compatibility

There are no known backward compatibility issues with this opcode.

## 7. Security Considerations

The value of the blob base-fee is not sensitive and is publicly accessible in the block header. There are no known security implications with this opcode.

## 8. License

The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

## 9. Reference

Carl Beekhuizen (@carlbeek), "EIP-7516: BLOBBASEFEE opcode [DRAFT]," Ethereum Improvement Proposals, no. 7516, September 2023. [Online serial]. Available: https://eips.ethereum.org/EIPS/eip-7516.