### PR TITLE
doc: remove broken doc links of BeaconChain BEPs

### DIFF
--- a/BEPs/BEP159.md
+++ b/BEPs/BEP159.md
@@ -170,7 +170,7 @@ After the implementation of this BEP:
 
 ### 5.2.6 Oracle Relayers
 
-The [oracle relayers](https://docs.bnbchain.org/docs/learn/oracle-relayer) are responsible for relaying cross-chain packages from BSC to BC. Currently they are separated services maintained by BC validators.
+The oracle relayers are responsible for relaying cross-chain packages from BSC to BC. Currently they are separated services maintained by BC validators.
 
 After the introduction of open staking mechanism, oracle relayers might also change frequently along with validators. It might affect the stability and security of the cross-chain process.
 

--- a/BEPs/BEP18.md
+++ b/BEPs/BEP18.md
@@ -13,16 +13,16 @@
       - [5.4.1 App state chunk](#541-app-state-chunk)
       - [5.4.2 Tendermint state chunk](#542-tendermint-state-chunk)
       - [5.4.3 Block chunk](#543-block-chunk)
-    - [5.5 Operation suggestion](#55-operation-suggestion)
+    - [5.5 Operation Suggestion](#55-operation-suggestion)
   - [6. License](#6-license)
 
 ## 1.  Summary
 
-This BEP describes [state sync](https://docs.bnbchain.org/docs/beaconchain/develop/node/synctypes/#state-sync) enhancement on the BNB Beacon Chain.
+This BEP describes state sync enhancement on the BNB Beacon Chain.
 
 ## 2.  Abstract
 
-[State sync](https://docs.bnbchain.org/docs/beaconchain/develop/node/synctypes/#state-sync) is a way to help newly-joined users sync the latest status of the BNB Beacon Chain. It syncs the latest sync-able peer's status so that fullnode user (who wants to catch up with chain as soon as possible with a cost that discards all historical blocks locally) doesn't need sync from block height 0.
+State sync is a way to help newly-joined users sync the latest status of the BNB Beacon Chain. It syncs the latest sync-able peer's status so that fullnode user (who wants to catch up with chain as soon as possible with a cost that discards all historical blocks locally) doesn't need sync from block height 0.
 
 BEP-18 Proposal describes an enhancement of existing state sync implementation to improve user experience. The status of the blockchain that can be synced is represented in a **"snapshot"**, which consists of a manifest file and a bunch of snapshot chunk files. The manifest file summarizes version, height, and checksums of snapshot chunk files of this snapshot. The snapshot chunk files contain encoded essential state data to recover a full node.
 

--- a/BEPs/BEP39.md
+++ b/BEPs/BEP39.md
@@ -11,13 +11,13 @@
 
 ## 1.  Summary 
 
-This BEP describes an improvement to the [Transfer Websocket](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/ws-streams#2-transfer).  
+This BEP describes an improvement to the Transfer Websocket.  
 
 ## 2.  Abstract
 
 BEP-39 requests that `MEMO` data field be added to the `/ws/userAddress` websocket. 
 
-Currently the `MEMO` field is not being returned on the websocket, which means that services that rely on `MEMO` to set transaction specifications must then retrieve it from the [Transaction API endpoint](https://docs.bnbchain.org/docs/beaconchain/develop/api-reference/dex-api/paths/#transaction).
+Currently the `MEMO` field is not being returned on the websocket, which means that services that rely on `MEMO` to set transaction specifications must then retrieve it from the Transaction API endpoint.
 
 This creates unnecessary burden on the API and slows down the transaction processing. 
 

--- a/BEPs/BEP6.md
+++ b/BEPs/BEP6.md
@@ -49,7 +49,6 @@ The DelistTradingPair proposal is similar to a governance proposal. It requires 
 |   InitialDeposit  |   coins    | Initial deposit paid by sender. Must be strictly positive |
 |    VotingPeriod   |   int      | Length of the voting period|
 
-For other document about governance proposal, please refer to this page: https://docs.bnbchain.org/docs/beaconchain/governance/#proposal-parameters
 
 ### 5.2 Cooling-Off Period
 Once a `DelistTradingPair` proposal is passed, it will enter a cooling-off period. The cooling-off period lasts until the next UTC 00:00 after the 72-hour point of the proposal passing.  As the name suggests, users should re-evaluate the market and take action on the proposed asset to be delisted. In this period, users can still create new orders and cancel orders on the trading pair. Once this period has ended, all outstanding orders will expire.

--- a/BEPs/BEP67.md
+++ b/BEPs/BEP67.md
@@ -1,6 +1,6 @@
 # BEP-67: Price-based Order Expiration
 
-- [BEP-67: Price-based Order Expiration](#bep-67-Price-based-order-expiration)
+- [BEP-67: Price-based Order Expiration](#bep-67-price-based-order-expiration)
   - [1. Summary](#1-summary)
   - [2. Abstract](#2-abstract)
   - [3. Status](#3-status)
@@ -8,11 +8,13 @@
   - [5. Specification](#5-specification)
     - [5.1 Order Expiration](#51-order-expiration)
     - [5.2 Change Impact](#52-change-impact)
+      - [5.2.1 Impact on Trader](#521-impact-on-trader)
+      - [5.2.2 Impact on BNB Beacon Chain](#522-impact-on-bnb-beacon-chain)
   - [6. License](#6-license)
 
 ## 1. Summary 
 
-This BEP describes an enhancement of the [Order Expiration](https://docs.bnbchain.org/docs/beaconchain/trading-spec/#order-expire).  
+This BEP describes an enhancement of the Order Expiration.
 
 ## 2. Abstract
 

--- a/BEPs/BEP70.md
+++ b/BEPs/BEP70.md
@@ -1,6 +1,6 @@
 # BEP70: List and Trade BUSD Pairs
 
-- [BEP-70: List and Trade BUSD Pairs](#bep-70-list-and-trade-buse-pairs)
+- [BEP70: List and Trade BUSD Pairs](#bep70-list-and-trade-busd-pairs)
   - [1. Summary](#1-summary)
   - [2. Abstract](#2-abstract)
   - [3. Status](#3-status)
@@ -37,9 +37,6 @@ Currently, for listing a trading pair between AAA and BUSD, there are following 
 + Existed trading pair between AAA and BNB
 + Existed trading pair between BUSD and BNB  
 
-For more information about governance proposal, please refer to the following page:   
-[https://docs.bnbchain.org/docs/beaconchain/governance](https://docs.bnbchain.org/docs/beaconchain/governance)
-
 #### 5.1.2 Proposed Changes
 For proposing and listing BUSD trading pairs, BUSD must be the base asset or quote asset. It means the BaseAssetSymbol or QuoteAssetSymbol must be BUSD-BD1 on the mainnet, and QuoteAssetSymbol or BaseAssetSymbol does not have to be BNB. 
 
@@ -53,9 +50,6 @@ With the proposed changes, for listing a trading pair between AAA and BUSD, the 
 
 ### 5.2 Trading Fee Calculation
 To calculate the trading fees, the price of BNB denominated in BUSD will be used if needed.
-For more information about trading fees, please refer to the following page:  
-[https://docs.bnbchain.org/docs/beaconchain/trading-spec/](https://docs.bnbchain.org/docs/beaconchain/trading-spec/)
-
 
 ## 6. License
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
1.After BC Fusion, BeaconChain was merged into BSC, so BC is no longer needed.
2.There is a [bnbchain docs site](https://docs.bnbchain.org/) refactor, many linkers are broken. Especially, the BC related urls are no longer provided.
3.It is better not to add external urls into BEPs docs.
Based on these points, I think we can simply remove these broken urls.