### PR TITLE
feat: bundle data API

### DIFF
--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -11,26 +11,26 @@
 <!-- TOC -->
 
 - [BEP-322: Builder API Specification for BNB Smart Chain](#bep-322-builder-api-specification-for-bnb-smart-chain)
-    - [1. Summary](#1-summary)
-    - [2. Motivation](#2-motivation)
-    - [3. Background](#3-background)
-        - [3.1 BSC Trust Model](#31-bsc-trust-model)
-        - [3.2 BSC Consensus](#32-bsc-consensus)
-    - [4 Workflow](#4-workflow)
-        - [4.1 Definition](#41-definition)
-        - [4.2 One-Round Interaction (default)](#42-one-round-interaction-default)
-        - [4.3 Two-Round Interaction (optional)](#43-two-round-interaction-optional)
-        - [4.4 APIs](#44-apis)
-            - [4.4.1 Builder APIs](#441-builder-apis)
-                - [4.4.1.1 Retrieve Transactions](#4411-retrieve-transactions)
-                - [4.4.1.2 Issues Report](#4412-issues-report)
-            - [4.4.2 Validator APIs](#442-validator-apis)
-                - [4.4.2.1 Bid Block](#4421-bid-block)
-    - [5. Further Discussion](#5-further-discussion)
-        - [5.1 Implementation Consideration](#51-implementation-consideration)
-        - [5.2 Payment \& Economic Considerations](#52-payment--economic-considerations)
-        - [5.3 Builder Registration](#53-builder-registration)
-    - [6. License](#6-license)
+  - [1. Summary](#1-summary)
+  - [2. Motivation](#2-motivation)
+  - [3. Background](#3-background)
+    - [3.1 BSC Trust Model](#31-bsc-trust-model)
+    - [3.2 BSC Consensus](#32-bsc-consensus)
+  - [4 Workflow](#4-workflow)
+    - [4.1 Definition](#41-definition)
+    - [4.2 One-Round Interaction (default)](#42-one-round-interaction-default)
+    - [4.3 Two-Round Interaction (optional)](#43-two-round-interaction-optional)
+    - [4.4 APIs](#44-apis)
+      - [4.4.1 Builder APIs](#441-builder-apis)
+        - [4.4.1.1 Retrieve Transactions](#4411-retrieve-transactions)
+        - [4.4.1.2 Issues Report](#4412-issues-report)
+      - [4.4.2 Validator APIs](#442-validator-apis)
+        - [4.4.2.1 Bid Block](#4421-bid-block)
+  - [5. Further Discussion](#5-further-discussion)
+    - [5.1 Implementation Consideration](#51-implementation-consideration)
+    - [5.2 Payment \& Economic Considerations](#52-payment--economic-considerations)
+    - [5.3 Builder Registration](#53-builder-registration)
+  - [6. License](#6-license)
 
 <!-- /TOC -->
 
@@ -390,7 +390,6 @@ Response:
 ```
 
 or some error:
-
 ```json
 {
   "jsonrpc": "2.0",
@@ -458,7 +457,7 @@ In BSC, one smart contract can be implemented to provide the following functiona
 - a builder can register to validators by providing its information (e.g., builder address).
 
 With this kind of smart contract, builders and validators can discover each other easily. It also provides transparency
-for all related stakeholders.
+for all related stakeholders. 
 
 ## 6. License
 

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -300,12 +300,10 @@ Request:
 ```json
 {
   "jsonrpc": "2.0",
-  "method": "mev_bundles",
+  "method": "eth_bundles",
   "params": [
-    {
-      "fromBlock": "0x1",
-      "toBlock": "0x3"
-    }
+    "0x1",
+    "0x3"
   ],
   "id": 1
 }
@@ -313,13 +311,13 @@ Request:
 
 Params:
 
-- `fromBlock`: It is hex value of a block number.
-- `toBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest". It
-  should be no less than `fromBlock` and less than `fromBlock+100`.
+1. String - `FromBlock`, It is the hex value of a block number.
+2. String - `ToBlock`, It is either the hex value of a block number OR block tags: "latest", "pending". It should be 
+no less than `FromBlock` and less than `FromBlock+100`.
 
 Response:
 
-* Return bundles whose first-received-height(`receivedBlock`)  is within the block range [`fromBlock`, `toBlock`].
+* Return bundles whose first-received-height(`receivedBlock`)  is within the block range [`FromBlock`, `ToBlock`].
 
 ```json
 {

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -288,6 +288,57 @@ Response:
 }
 ```
 
+##### 4.4.1.3 Query Bundle Data
+
+This API is used by mev data analysts to query the bundle information from the builder. For example, In order to be able 
+to directly reflect the mev market size, the mev data provider launches a bundle panel needs to show the number of 
+bundles per day or per block.
+
+Request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "mev_bundles",
+  "params": [
+    {
+      "fromBlock": "0x1",
+      "toBlock": "0x2"
+    }
+  ],
+  "id": 1
+}
+```
+* The diff between fromBlock and toBlock should be less than 100.
+
+Response:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "blockNumber": "0x1",
+      "bundleCount": "0x2",
+      "bundles": [
+        {"txHashes": ["0x88...44b", "0x89..45b", "0x90...46b"]},
+        {"txHashes": ["0x23...24b", "0x39..45b"]}
+      ]
+    },
+    {
+      "blockNumber": "0x2",
+      "bundleCount": "0x3",
+      "bundles": [
+        {"txHashes": ["0x88...44b", "0x89..45b", "0x90...46b"]},
+        {"txHashes": ["0x23...24b", "0x39..45b"]},
+        {"txHashes": ["0x27...f4b", "0x94..4cb"]}
+      ]
+    }
+  ],
+  "id": 1
+}
+```
+
 #### 4.4.2 Validator APIs
 
 The following APIs should be implemented on the validator side or BSC clients.

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -318,7 +318,7 @@ Params:
 
 Response:
 
-* Return only bundles whose first-received-height is within the block range, regardless of the bundle end time.
+* Return only bundles whose first-received-height(`fromBlock`)  is within the block range, regardless of the bundle's `endBlock`.
 
 ```json
 {

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -319,27 +319,24 @@ Params:
 
 Response:
 
-* Return bundles whose first-received-height(`fromBlock`)  is within the block range.
+* Return bundles whose first-received-height(`receivedBlock`)  is within the block range [`fromBlock`, `toBlock`].
 
 ```json
 {
   "jsonrpc": "2.0",
   "result": [
     {
-      "receivedAt": "0x1",
+      "receivedBlock": "0x1",
       "bundles": [
-        ["0x88...44b", // tx hash 
-        "0x89..45b"],
+        ["0x88...44b", "0x89..45b"], // tx hase list in the bundle
         ["0x90...46b"]
       ]
     },
     {
-      "receivedAt": "0x2",
+      "receivedBlock": "0x2",
       "bundles": [
-        ["0x23...24b",
-        "0x39..45b"],
-        ["0x43...55a",
-          "0x45..33a"]  //  it is possible that a same tx hash exist in different block
+        ["0x23...24b", "0x39..45b"],
+        ["0x43...55a", "0x45..33a", "0x39..45b"]  //  it is possible that a same tx hash exists in different block
       ]
     }
   ],

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -11,26 +11,26 @@
 <!-- TOC -->
 
 - [BEP-322: Builder API Specification for BNB Smart Chain](#bep-322-builder-api-specification-for-bnb-smart-chain)
-  - [1. Summary](#1-summary)
-  - [2. Motivation](#2-motivation)
-  - [3. Background](#3-background)
-    - [3.1 BSC Trust Model](#31-bsc-trust-model)
-    - [3.2 BSC Consensus](#32-bsc-consensus)
-  - [4 Workflow](#4-workflow)
-    - [4.1 Definition](#41-definition)
-    - [4.2 One-Round Interaction (default)](#42-one-round-interaction-default)
-    - [4.3 Two-Round Interaction (optional)](#43-two-round-interaction-optional)
-    - [4.4 APIs](#44-apis)
-      - [4.4.1 Builder APIs](#441-builder-apis)
-        - [4.4.1.1 Retrieve Transactions](#4411-retrieve-transactions)
-        - [4.4.1.2 Issues Report](#4412-issues-report)
-      - [4.4.2 Validator APIs](#442-validator-apis)
-        - [4.4.2.1 Bid Block](#4421-bid-block)
-  - [5. Further Discussion](#5-further-discussion)
-    - [5.1 Implementation Consideration](#51-implementation-consideration)
-    - [5.2 Payment \& Economic Considerations](#52-payment--economic-considerations)
-    - [5.3 Builder Registration](#53-builder-registration)
-  - [6. License](#6-license)
+    - [1. Summary](#1-summary)
+    - [2. Motivation](#2-motivation)
+    - [3. Background](#3-background)
+        - [3.1 BSC Trust Model](#31-bsc-trust-model)
+        - [3.2 BSC Consensus](#32-bsc-consensus)
+    - [4 Workflow](#4-workflow)
+        - [4.1 Definition](#41-definition)
+        - [4.2 One-Round Interaction (default)](#42-one-round-interaction-default)
+        - [4.3 Two-Round Interaction (optional)](#43-two-round-interaction-optional)
+        - [4.4 APIs](#44-apis)
+            - [4.4.1 Builder APIs](#441-builder-apis)
+                - [4.4.1.1 Retrieve Transactions](#4411-retrieve-transactions)
+                - [4.4.1.2 Issues Report](#4412-issues-report)
+            - [4.4.2 Validator APIs](#442-validator-apis)
+                - [4.4.2.1 Bid Block](#4421-bid-block)
+    - [5. Further Discussion](#5-further-discussion)
+        - [5.1 Implementation Consideration](#51-implementation-consideration)
+        - [5.2 Payment \& Economic Considerations](#52-payment--economic-considerations)
+        - [5.3 Builder Registration](#53-builder-registration)
+    - [6. License](#6-license)
 
 <!-- /TOC -->
 
@@ -290,8 +290,8 @@ Response:
 
 ##### 4.4.1.3 Query Bundle Data
 
-This API is used by mev data analysts to query the bundle information from the builder. For example, In order to be able 
-to directly reflect the mev market size, the mev data provider launches a bundle panel needs to show the number of 
+This API is used by mev data analysts to query the bundle information from the builder. For example, In order to be able
+to directly reflect the mev market size, the mev data provider launches a bundle panel needs to show the number of
 bundles per day or per block.
 
 Request:
@@ -303,13 +303,18 @@ Request:
   "params": [
     {
       "fromBlock": "0x1",
-      "toBlock": "0x2"
+      "toBlock": "0x3"
     }
   ],
   "id": 1
 }
 ```
-* The diff between fromBlock and toBlock should be less than 100.
+
+Params:
+
+- `fromBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest".
+- `toBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest". It
+  should be no less than `fromBlock` and less than `fromBlock+100`.
 
 Response:
 
@@ -318,20 +323,20 @@ Response:
   "jsonrpc": "2.0",
   "result": [
     {
-      "blockNumber": "0x1",
-      "bundleCount": "0x2",
-      "bundles": [
-        {"txHashes": ["0x88...44b", "0x89..45b", "0x90...46b"]},
-        {"txHashes": ["0x23...24b", "0x39..45b"]}
+      "fromBlock": "0x1",
+      "toBlock": "0x2",
+      "bundleTxHashes": [
+        "0x88...44b",
+        "0x89..45b",
+        "0x90...46b"
       ]
     },
     {
-      "blockNumber": "0x2",
-      "bundleCount": "0x3",
-      "bundles": [
-        {"txHashes": ["0x88...44b", "0x89..45b", "0x90...46b"]},
-        {"txHashes": ["0x23...24b", "0x39..45b"]},
-        {"txHashes": ["0x27...f4b", "0x94..4cb"]}
+      "fromBlock": "0x2",
+      "toBlock": "0x3",
+      "bundleTxHashes": [
+        "0x23...24b",
+        "0x39..45b"
       ]
     }
   ],
@@ -385,6 +390,7 @@ Response:
 ```
 
 or some error:
+
 ```json
 {
   "jsonrpc": "2.0",
@@ -452,7 +458,7 @@ In BSC, one smart contract can be implemented to provide the following functiona
 - a builder can register to validators by providing its information (e.g., builder address).
 
 With this kind of smart contract, builders and validators can discover each other easily. It also provides transparency
-for all related stakeholders. 
+for all related stakeholders.
 
 ## 6. License
 

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -290,9 +290,10 @@ Response:
 
 ##### 4.4.1.3 Query Bundle Data
 
-This API is used by mev data analysts to query the bundle information from the builder. For example, In order to be able
-to directly reflect the mev market size, the mev data provider launches a bundle panel needs to show the number of
-bundles per day or per block.
+This API enables MEV data analysts to query bundle information from builders. 
+It is particularly useful for MEV data providers who need to analyze market trends and create analytics dashboards. 
+For instance, to accurately measure MEV market activity, providers can use this API to display metrics such as 
+daily bundle counts and bundles per block in their analytics panels.
 
 Request:
 
@@ -312,33 +313,33 @@ Request:
 
 Params:
 
-- `fromBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest".
+- `fromBlock`: It is hex value of a block number.
 - `toBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest". It
   should be no less than `fromBlock` and less than `fromBlock+100`.
 
 Response:
 
-* Return only bundles whose first-received-height(`fromBlock`)  is within the block range, regardless of the bundle's `endBlock`.
+* Return bundles whose first-received-height(`fromBlock`)  is within the block range.
 
 ```json
 {
   "jsonrpc": "2.0",
   "result": [
     {
-      "fromBlock": "0x1",
-      "toBlock": "0x2",
-      "bundleTxHashes": [
-        "0x88...44b",
-        "0x89..45b",
-        "0x90...46b"
+      "receivedAt": "0x1",
+      "bundles": [
+        ["0x88...44b", // tx hash 
+        "0x89..45b"],
+        ["0x90...46b"]
       ]
     },
     {
-      "fromBlock": "0x2",
-      "toBlock": "0x3",
-      "bundleTxHashes": [
-        "0x23...24b",
-        "0x39..45b"
+      "receivedAt": "0x2",
+      "bundles": [
+        ["0x23...24b",
+        "0x39..45b"],
+        ["0x43...55a",
+          "0x45..33a"]  //  it is possible that a same tx hash exist in different block
       ]
     }
   ],

--- a/BEPs/BEP322.md
+++ b/BEPs/BEP322.md
@@ -318,6 +318,8 @@ Params:
 
 Response:
 
+* Return only bundles whose first-received-height is within the block range, regardless of the bundle end time.
+
 ```json
 {
   "jsonrpc": "2.0",


### PR DESCRIPTION
### Description

##### 4.4.1.3 Query Bundle Data

This API enables MEV data analysts to query bundle information from builders. 
It is particularly useful for MEV data providers who need to analyze market trends and create analytics dashboards. 
For instance, to accurately measure MEV market activity, providers can use this API to display metrics such as 
daily bundle counts and bundles per block in their analytics panels.

Request:

```json
{
  "jsonrpc": "2.0",
  "method": "mev_bundles",
  "params": [
    {
      "fromBlock": "0x1",
      "toBlock": "0x3"
    }
  ],
  "id": 1
}
```

Params:

- `fromBlock`: It is hex value of a block number.
- `toBlock`: Either the hex value of a block number OR block tags: "latest", "pending" or nil. Defaults to "latest". It
  should be no less than `fromBlock` and less than `fromBlock+100`.

Response:

* Return bundles whose first-received-height(`receivedBlock`)  is within the block range [`fromBlock`, `toBlock`].

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "receivedBlock": "0x1",
      "bundles": [
        ["0x88...44b", "0x89..45b"], // tx hase list in the bundle
        ["0x90...46b"]
      ]
    },
    {
      "receivedBlock": "0x2",
      "bundles": [
        ["0x23...24b", "0x39..45b"],
        ["0x43...55a", "0x45..33a", "0x39..45b"]  //  it is possible that a same tx hash exists in different block
      ]
    }
  ],
  "id": 1
}
```