### PR TITLE
BEP-525: update Validator Dedicated Network design

### DIFF
--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -1,19 +1,19 @@
 <pre>
   BEP: 525
-  Title: Validator Dedicated Network
+  Title: Validator Dedicated Network And Directed TxPool
   Status: Draft
   Type: Standards
   Created: 2025-02-19
   Discussions(optional): https://forum.bnbchain.org/t/idea-faster-p2p-network-for-validators/3282
 </pre>
 
-# BEP-525: Validator Dedicated Network
-- [BEP-525: Validator Dedicated Network](#bep-525-validator-dedicated-network)
+# BEP-525: Validator Dedicated Network And Directed TxPool
+- [BEP-525: Validator Dedicated Network And Directed TxPool](#bep-525-validator-dedicated-network-and-directed-txpool)
   - [1. Summary](#1-summary)
   - [2. Motivation](#2-motivation)
   - [3. Specification](#3-specification)
     - [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
-    - [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
+    - [3.2.Directed TxPool](#32directed-txpool)
     - [3.3.Messages](#33messages)
       - [Handshake v1](#handshake-v1)
       - [ContactInfo v1](#contactinfo-v1)
@@ -22,13 +22,17 @@
       - [Vote v1](#vote-v1)
       - [Transactions v1](#transactions-v1)
   - [4. Backwards Compatibility](#4-backwards-compatibility)
+    - [4.1 Validator Operator](#41-validator-operator)
+    - [4.2.RPC Providers And Other Full Nodes Operators](#42rpc-providers-and-other-full-nodes-operators)
+    - [4.3 MEV](#43-mev)
   - [5. License](#5-license)
 
 ## 1. Summary
-Add a network layer, which accept validator or validator authorized node to join in to improve the network efficiency and reduce network latency between validators.
+It is a new network topology, which only accepts validators or validator authorized nodes and transactions in this network will be forwarded directionally to a few validators that are most likely to produce the next block.
 
 ## 2. Motivation
-Low latency is one of the key user experience and if BSC wanna to support shorter block interval, network latency between validators could be crucial to support sub-second block interval. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots network bandwidth and also cost non-negligible latency. Validators are the key player to sustain the network, so one validator dedicated network layer could help to address the two issues.
+- For low network latency between validators: transaction latency is one of the key user experience. As BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots network bandwidth and also cost non-negligible latency.
+- For MEV protection: validators are the key role in the network, it is reasonable that validators have the highest priority to get the transactions. Directed txpool means transactions would only be forwarded to a small subset of validators that are most likely to produce the next block. It could avoid exposing users transactions directly to public txpool, so users would less likely to face malicious MEV attack
 
 ## 3. Specification
 ### 3.1.Validator Dedicated Network(VDN)
@@ -42,12 +46,11 @@ There would be some several roles in VDN:
 
 ![overview](./assets/BEP-525/3-1.png)
 
-### 3.2.Directional Transactions Broadcast
+### 3.2.Directed TxPool
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.
 
 ### 3.3.Messages
-
-It is recommended to use the QUIC protocol to send messages and broadcast messages based on the pubsub mechanism. All messages are `RLP encoded`.
+There would be a new protocol to define the messages that are broadcasted within VDN. These messages would be transmitted with QUIC protocol and will be based on the pubsub mechanism. All messages are `RLP encoded`.
 
 #### Handshake v1
 Protocol ID: `/bsc/vdn/v1/handshake`
@@ -190,7 +193,16 @@ Response Content:
 When the validator receives the block, it sends the current pending txs to the next inturn validator.
 
 ## 4. Backwards Compatibility
-TBD
+### 4.1 Validator Operator
+Operators would need to change their node's network configuration to integrate VDN. They would need fully understand the new topology and may setup the validator-sentry and validator-proxy node respectively. They may also need to monitor their network quality to provide good network quality.
+
+### 4.2.RPC Providers And Other Full Nodes Operators
+Depends on the strategy of the RPC providers and other full nodes, they may connect to validator-sentry nodes directly, so it would have lower latency and user's transaction would be protected as these transaction would not be leaked to public txpool. But they can also choose to not connect to validator-sentry nodes directly and forward transactions to validators through a different route path.
+
+### 4.3 MEV
+This BEP would have great impact to MEV ecosystem, as the public txpool would be gradually replaced by validator directed txpool, which means transactions would be forwarded to validators directly.
+- MEV searchers would have to get the transactions from validators, which would be more difficult.
+- MEV builders can still act as a bridge between searchers and validators, but the impact to searchers would impact builders indirectly.
 
 ## 5. License
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -28,23 +28,25 @@
   - [5. License](#5-license)
 
 ## 1. Summary
-It is a new network topology, which only accepts validators or validator authorized nodes and transactions in this network will be forwarded directionally to a few validators that are most likely to produce the next block.
+It is a new network topology, which only accepts validators or validator authorized nodes tp join and transactions in this network will be forwarded directionally to a few validators that are most likely to produce the next block.
 
 ## 2. Motivation
-- For low network latency between validators: transaction latency is one of the key user experience. As BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots network bandwidth and also cost non-negligible latency.
-- For MEV protection: validators are the key role in the network, it is reasonable that validators have the highest priority to get the transactions. Directed txpool means transactions would only be forwarded to a small subset of validators that are most likely to produce the next block. It could avoid exposing users transactions directly to public txpool, so users would less likely to face malicious MEV attack
+- For low network latency between validators: transaction latency is one of the key user experience. As BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots of network bandwidth and also cost non-negligible latency.
+- For MEV protection: validators are the key role in the network, it is reasonable that validators have the highest priority to get the transactions. Directed txpool means transactions would be forwarded to a small subset of validators that are most likely to produce the next block. It could avoid exposing users transactions directly to public txpool, so users would less likely to face malicious MEV attacks.
 
 ## 3. Specification
 ### 3.1.Validator Dedicated Network(VDN)
-The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 
+The general network topology can be described by the following diagram:
 
-There would be some several roles in VDN:
+![overview](./assets/BEP-525/3-1.png)
+
+Basically validators would be able to find and connect each other to reduce the network latency.
+Here is the description of these roles in VDN:
 - VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
 - Validator: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
 - Validator-Sentry(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
 - Validator-Proxy(optional): in case validator don’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 
-![overview](./assets/BEP-525/3-1.png)
 
 ### 3.2.Directed TxPool
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -40,13 +40,13 @@ The general network topology can be described by the following diagram:
 
 ![overview](./assets/BEP-525/3-1.png)
 
-Basically validators would be able to find and connect each other to reduce the network latency.
-Here is the description of these roles in VDN:
-- VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
-- Validator: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
-- Validator-Sentry(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
-- Validator-Proxy(optional): in case validator don’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
+Basically validators would be able to find and connect with each other to reduce the network latency.
 
+Here is the description of these roles in VDN:
+- **VDN-BootNode**: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
+- **Validator**: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
+- **Validator-Sentry**(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
+- **Validator-Proxy**(optional): in case validator don’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 
 ### 3.2.Directed TxPool
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -28,12 +28,12 @@
   - [5. License](#5-license)
 
 ## 1. Summary
-It is a new network topology, which only accepts validators or validator authorized nodes tp join and transactions in this network will be forwarded directionally to a few validators that are most likely to produce the next block.
+This is a new network topology that only accepts validators or nodes authorized by validators. Transactions in this network will be forwarded directly to a few validators who are most likely to produce the next block.
 
 ## 2. Motivation
-- For low network latency between validators: transaction latency is one of the key user experience. As BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots of network bandwidth and also cost non-negligible latency.
+- For low network latency between validators: as BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots of network bandwidth and also cost non-negligible latency.
 - For MEV protection: validators are the key role in the network, it is reasonable that validators have the highest priority to get the transactions. Directed txpool means transactions would be forwarded to a small subset of validators that are most likely to produce the next block. It could avoid exposing users transactions directly to public txpool, so users would less likely to face malicious MEV attacks.
-
+For E2E latency: transaction latency is one of the key user experiences. Directed TxPool can accelerate transaction confirmation times while reducing the risk of malicious MEV attacks.
 ## 3. Specification
 ### 3.1.Validator Dedicated Network(VDN)
 The general network topology can be described by the following diagram:
@@ -45,8 +45,8 @@ Basically validators would be able to find and connect with each other to reduce
 Here is the description of these roles in VDN:
 - **VDN-BootNode**: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
 - **Validator**: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
-- **Validator-Sentry**(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
-- **Validator-Proxy**(optional): in case validator don’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
+- **Validator-Sentry**(optional): it acts as a bridge between the public network and a validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
+- **Validator-Proxy**(optional): in case validator doesn’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 
 ### 3.2.Directed TxPool
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.
@@ -199,7 +199,7 @@ When the validator receives the block, it sends the current pending txs to the n
 Operators would need to change their node's network configuration to integrate VDN. They would need fully understand the new topology and may setup the validator-sentry and validator-proxy node respectively. They may also need to monitor their network quality to provide good network quality.
 
 ### 4.2.RPC Providers And Other Full Nodes Operators
-Depends on the strategy of the RPC providers and other full nodes, they may connect to validator-sentry nodes directly, so it would have lower latency and user's transaction would be protected as these transaction would not be leaked to public txpool. But they can also choose to not connect to validator-sentry nodes directly and forward transactions to validators through a different route path.
+Depends on the strategy of the RPC providers and other full nodes, they may connect to validator-sentry nodes directly, so it would have lower latency and user's transaction would be protected as these transaction would not be leaked to public txpool. But they can also choose to not connect to validator-sentry nodes directly and forward transactions to validators through a different route path. The public network composed by these full nodes will mainly help on block syncing, while transaction will not be gossiped in this public network.
 
 ### 4.3 MEV
 This BEP would have great impact to MEV ecosystem, as the public txpool would be gradually replaced by validator directed txpool, which means transactions would be forwarded to validators directly.

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -37,13 +37,13 @@ The general network layout is described in the bellow diagram, basically validat
 There would be some new roles in VDN:
 - VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
 - Validator: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
-- Validator-Sentry(optional): it acts as the bridge between public network and validator. Transactions can be sent to this sentry node through RPC call or based current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
-- Validator-Proxy(optional): in case validator don’t wanna expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
+- Validator-Sentry(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
+- Validator-Proxy(optional): in case validator don’t want to expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 
 ![overview](./assets/BEP-525/3-1.png)
 
 ### 3.2.Directional Transactions Broadcast
-It is another key aspect of VDN, transactions that are broadcasted in VDN would no long gossip based, on the opposite, they will only be broadcasted to nextN validators which have the right to propose next block.
+It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.
 
 In order to receive transactions from SentryProxy or RPC Provider, the sender needs to implement a batch send transaction. This can be done by using JSON-RPC batch request implementation with `eth_sendRawTransaction`. The receiver only receives transactions in batches and must not package the incoming transactions as a bundler.
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -35,7 +35,7 @@ Low latency is one of the key user experience and if BSC wanna to support shorte
 The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 
 
 There would be some new roles in VDN:
-- BootNode: it is help validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
+- VDN-BootNode: it helps validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
 - Validator Node: join the network through bootnode, discover all validators in the network, connect to active validator nodes, and exchange messages.
 - Validator-RPC-Sentry: transactions can be sent to this sentry node and it will forward it to the corresponding validator nodes.
 - Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -28,7 +28,8 @@ Low latency is one of the key user experience and if BSC wanna to support shorte
 The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 
 
 There would be some new roles in VDN:
-- Validatot BootNode: it is help validators to discover each other and establish the connection
+- BootNode: it is help validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
+- Validator Node: join the network through bootnode, discover all validators in the network, connect to active validator nodes, and exchange messages.
 - Validator-RPC-Sentry: transactions can be sent to this sentry node and it will forward it to the corresponding validator nodes.
 - Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.
 
@@ -36,6 +37,137 @@ There would be some new roles in VDN:
 
 ### 3.2.Directional Transactions Broadcast
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long gossip based, on the opposite, they will only be broadcasted to nextN validators which have the right to propose next block.
+
+In order to receive transactions from SentryProxy or RPC Provider, the sender needs to implement a batch send transaction. This can be done by using JSON-RPC batch request implementation with `eth_sendRawTransaction`. The receiver only receives transactions in batches and must not package the incoming transactions as a bundler.
+
+### 3.3.Messages
+
+It is recommended to use the QUIC protocol to send messages and broadcast messages based on the pubsub mechanism. All messages are RLP encoded.
+
+#### handshake v1
+Protocol ID: `/bsc/vdn/v1/handshake`
+
+Request & Response Content:
+
+```
+(
+  chainID: uint64
+  forkID: [4]byte
+  genesis_hash: Hash
+  timestamp: Time
+  extend: []byte
+  pub_key: PublicKey
+  sign: Signature
+)
+```
+
+Node must check `chainID`, `forkID`, `genesis_hash`, and `extend` is empty now. Only validators registered with the staking contract are allowed to connect.
+
+#### ContactInfo v1
+Protocol ID: `/bsc/vdn/v1/contact_info`
+
+Request Content:
+
+```
+(
+  listen_p2p_addrs: []Address // validator can connect other validator with these addresses.
+  listen_tx_addrs: []Address // RPC provider or Sentry Proxy can batch send txs with these url.
+  cache: []Concact // max 8 cache node's contact
+  timestamp: Time
+)
+```
+
+Response Content:
+
+```
+(
+  code: StatusCode
+)
+```
+
+Node will broadcast its ContactInfo periodly.
+
+#### Block v1
+Protocol ID: `/bsc/vdn/v1/block`
+
+Request Content:
+
+```
+(
+  block: Block
+  timestamp: Time
+)
+```
+
+Response Content:
+
+```
+(
+  code: StatusCode
+)
+```
+
+#### RequestBlockByRange v1
+Protocol ID: `/bsc/vdn/v1/req/block_by_range`
+
+Request Content:
+
+```
+(
+  start_height: uint64
+  count: uint64
+  timestamp: Time
+)
+```
+
+Response Content:
+
+```
+(
+  code: StatusCode
+  blocks: []Block
+)
+```
+
+#### Vote v1
+Protocol ID: `/bsc/vdn/v1/vote`
+
+Request Content:
+
+```
+(
+  vote: Vote
+  timestamp: Time
+)
+```
+
+Response Content:
+
+```
+(
+  code: StatusCode
+)
+```
+
+#### Transactions v1
+Protocol ID: `/bsc/vdn/v1/Transactions`
+
+Request Content:
+
+```
+(
+  txs: []Transaction // not exist 10MB in total msg size
+  timestamp: Time
+)
+```
+
+Response Content:
+
+```
+(
+  code: StatusCode
+)
+```
 
 ## 4. Backwards Compatibility
 TBD

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -38,7 +38,7 @@ There would be some new roles in VDN:
 - VDN-BootNode: it helps validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
 - Validator: join the network through VDN-BootNode, discover and connect to other validators in VDN and exchange messages.
 - Validator-Sentry(optional): it acts as the bridge between public network and validator. Transactions can be sent to this sentry node through RPC call or based current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
-- Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.
+- Validator-Proxy(optional): in case validator don’t wanna expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 
 ![overview](./assets/BEP-525/3-1.png)
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -178,7 +178,7 @@ Request Content:
 
 ```
 (
-  txs: []Transaction // not exist 10MB in total msg size
+  txs: []Transaction // not exceed 10MB in total msg size
 )
 ```
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -35,7 +35,7 @@ Low latency is one of the key user experience and if BSC wanna to support shorte
 The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 
 
 There would be some new roles in VDN:
-- VDN-BootNode: it helps validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
+- VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
 - Validator: join the network through VDN-BootNode, discover and connect to other validators in VDN and exchange messages.
 - Validator-Sentry(optional): it acts as the bridge between public network and validator. Transactions can be sent to this sentry node through RPC call or based current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
 - Validator-Proxy(optional): in case validator don’t wanna expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -124,7 +124,7 @@ Response Content:
 
 After the inturn validator packs a block, it will immediately send the block to the next N inturn validators.
 
-> N refers to the number of validators that rotate out blocks in the current epoch.
+> N refers to the number of validators that produce blocks in the current epoch.
 
 #### RequestBlockByRange v1
 Protocol ID: `/bsc/vdn/v1/req/block_by_range`

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -36,7 +36,7 @@ The general network layout is described in the bellow diagram, basically validat
 
 There would be some new roles in VDN:
 - VDN-BootNode: it helps validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
-- Validator Node: join the network through bootnode, discover all validators in the network, connect to active validator nodes, and exchange messages.
+- Validator: join the network through VDN-BootNode, discover and connect to other validators in VDN and exchange messages.
 - Validator-RPC-Sentry: transactions can be sent to this sentry node and it will forward it to the corresponding validator nodes.
 - Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -98,7 +98,7 @@ Response Content:
 )
 ```
 
-After the validator joins the network, it will periodically send its contact info to the network. 
+After the validator joins the network, it will periodically send its contact info and also the cached contact info to the network.
 
 Once it connects to most nodes, it will reduce the sending frequency.
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -68,7 +68,7 @@ Request & Response Content:
 )
 ```
 
-Node must check `chainID`, `forkID`, `genesis_hash`, and `extend` is empty now. Only validators registered with the staking contract are allowed to connect.
+`chainID`, `forkID`, `genesis_hash` should be valid value, and `extend` is empty now which is reserved for future usage. Only validators registered with the staking contract are allowed to connect.
 
 Once the validator connects to any node, it will initiate a handshake. If the verification fails, it will disconnect.
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -36,7 +36,7 @@ The general network layout is described in the bellow diagram, basically validat
 
 There would be some new roles in VDN:
 - VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
-- Validator: join the network through VDN-BootNode, discover and connect to other validators in VDN and exchange messages.
+- Validator: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
 - Validator-Sentry(optional): it acts as the bridge between public network and validator. Transactions can be sent to this sentry node through RPC call or based current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
 - Validator-Proxy(optional): in case validator don’t wanna expose itself to public network, it could authorise one or more proxy nodes to connect to the VDN.
 

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -9,20 +9,20 @@
 
 # BEP-525: Validator Dedicated Network
 - [BEP-525: Validator Dedicated Network](#bep-525-validator-dedicated-network)
-  * [1. Summary](#1-summary)
-  * [2. Motivation](#2-motivation)
-  * [3. Specification](#3-specification)
-    + [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
-    + [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
-    + [3.3.Messages](#33messages)
+  - [1. Summary](#1-summary)
+  - [2. Motivation](#2-motivation)
+  - [3. Specification](#3-specification)
+    - [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
+    - [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
+    - [3.3.Messages](#33messages)
       - [Handshake v1](#handshake-v1)
       - [ContactInfo v1](#contactinfo-v1)
       - [Block v1](#block-v1)
       - [RequestBlockByRange v1](#requestblockbyrange-v1)
       - [Vote v1](#vote-v1)
       - [Transactions v1](#transactions-v1)
-  * [4. Backwards Compatibility](#4-backwards-compatibility)
-  * [5. License](#5-license)
+  - [4. Backwards Compatibility](#4-backwards-compatibility)
+  - [5. License](#5-license)
 
 ## 1. Summary
 Add a network layer, which accept validator or validator authorized node to join in to improve the network efficiency and reduce network latency between validators.
@@ -34,7 +34,7 @@ Low latency is one of the key user experience and if BSC wanna to support shorte
 ### 3.1.Validator Dedicated Network(VDN)
 The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 
 
-There would be some new roles in VDN:
+There would be some several roles in VDN:
 - VDN-BootNode: It helps validators discover each other and establish connections, and only validators registered with the staking contract are allowed to connect.
 - Validator: joins the network through the VDN-BootNode, discover and connect with other validators in the VDN, and exchange messages.
 - Validator-Sentry(optional): it acts as a bridge between public network and validator. Transactions can be sent to this sentry node through RPC calls or through the current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
@@ -44,8 +44,6 @@ There would be some new roles in VDN:
 
 ### 3.2.Directional Transactions Broadcast
 It is another key aspect of VDN, transactions that are broadcasted in VDN would no long be gossip based, on the opposite, they will only be broadcasted to next {N} validators which have the highest priority to propose the next block, the value of {N} is configurable, by default it would be 3, which means 1 in-turn validator and 2 off-turn validator.
-
-In order to receive transactions from SentryProxy or RPC Provider, the sender needs to implement a batch send transaction. This can be done by using JSON-RPC batch request implementation with `eth_sendRawTransaction`. The receiver only receives transactions in batches and must not package the incoming transactions as a bundler.
 
 ### 3.3.Messages
 
@@ -84,7 +82,6 @@ Request Content:
   peer_id: string
   pub_key: PublicKey
   listen_p2p_addrs: []Address // validator can connect it by the addresses.
-  listen_tx_addrs: []Address // RPC provider or Sentry Proxy can batch send txs by the urls.
   cache: []Concact // max 8 cache node's contact
   create_time: Time
 )

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -9,13 +9,20 @@
 
 # BEP-525: Validator Dedicated Network
 - [BEP-525: Validator Dedicated Network](#bep-525-validator-dedicated-network)
-  - [1. Summary](#1-summary)
-  - [2. Motivation](#2-motivation)
-  - [3. Specification](#3-specification)
-    - [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
-    - [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
-  - [4. Backwards Compatibility](#4-backwards-compatibility)
-  - [5. License](#5-license)
+  * [1. Summary](#1-summary)
+  * [2. Motivation](#2-motivation)
+  * [3. Specification](#3-specification)
+    + [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
+    + [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
+    + [3.3.Messages](#33messages)
+      - [Handshake v1](#handshake-v1)
+      - [ContactInfo v1](#contactinfo-v1)
+      - [Block v1](#block-v1)
+      - [RequestBlockByRange v1](#requestblockbyrange-v1)
+      - [Vote v1](#vote-v1)
+      - [Transactions v1](#transactions-v1)
+  * [4. Backwards Compatibility](#4-backwards-compatibility)
+  * [5. License](#5-license)
 
 ## 1. Summary
 Add a network layer, which accept validator or validator authorized node to join in to improve the network efficiency and reduce network latency between validators.
@@ -42,9 +49,9 @@ In order to receive transactions from SentryProxy or RPC Provider, the sender ne
 
 ### 3.3.Messages
 
-It is recommended to use the QUIC protocol to send messages and broadcast messages based on the pubsub mechanism. All messages are RLP encoded.
+It is recommended to use the QUIC protocol to send messages and broadcast messages based on the pubsub mechanism. All messages are `RLP encoded`.
 
-#### handshake v1
+#### Handshake v1
 Protocol ID: `/bsc/vdn/v1/handshake`
 
 Request & Response Content:
@@ -54,7 +61,7 @@ Request & Response Content:
   chainID: uint64
   forkID: [4]byte
   genesis_hash: Hash
-  timestamp: Time
+  node_version: string
   extend: []byte
   pub_key: PublicKey
   sign: Signature
@@ -63,6 +70,10 @@ Request & Response Content:
 
 Node must check `chainID`, `forkID`, `genesis_hash`, and `extend` is empty now. Only validators registered with the staking contract are allowed to connect.
 
+Once the validator connects to any node, it will initiate a handshake. If the verification fails, it will disconnect.
+
+After the connection is successful, it will periodically send handshakes. Once it finds that the validator is no longer active, it will disconnect.
+
 #### ContactInfo v1
 Protocol ID: `/bsc/vdn/v1/contact_info`
 
@@ -70,10 +81,12 @@ Request Content:
 
 ```
 (
-  listen_p2p_addrs: []Address // validator can connect other validator with these addresses.
-  listen_tx_addrs: []Address // RPC provider or Sentry Proxy can batch send txs with these url.
+  peer_id: string
+  pub_key: PublicKey
+  listen_p2p_addrs: []Address // validator can connect it by the addresses.
+  listen_tx_addrs: []Address // RPC provider or Sentry Proxy can batch send txs by the urls.
   cache: []Concact // max 8 cache node's contact
-  timestamp: Time
+  create_time: Time
 )
 ```
 
@@ -85,7 +98,9 @@ Response Content:
 )
 ```
 
-Node will broadcast its ContactInfo periodly.
+After the validator joins the network, it will periodically send its contact info to the network. 
+
+Once it connects to most nodes, it will reduce the sending frequency.
 
 #### Block v1
 Protocol ID: `/bsc/vdn/v1/block`
@@ -95,7 +110,7 @@ Request Content:
 ```
 (
   block: Block
-  timestamp: Time
+  create_time: Time
 )
 ```
 
@@ -106,6 +121,10 @@ Response Content:
   code: StatusCode
 )
 ```
+
+After the inturn validator packs a block, it will immediately send the block to the next N inturn validators.
+
+> N refers to the number of validators that rotate out blocks in the current epoch.
 
 #### RequestBlockByRange v1
 Protocol ID: `/bsc/vdn/v1/req/block_by_range`
@@ -116,7 +135,6 @@ Request Content:
 (
   start_height: uint64
   count: uint64
-  timestamp: Time
 )
 ```
 
@@ -129,6 +147,8 @@ Response Content:
 )
 ```
 
+When the validator receives the future block, it requests the missing block from the source node.
+
 #### Vote v1
 Protocol ID: `/bsc/vdn/v1/vote`
 
@@ -137,7 +157,7 @@ Request Content:
 ```
 (
   vote: Vote
-  timestamp: Time
+  create_time: Time
 )
 ```
 
@@ -149,15 +169,16 @@ Response Content:
 )
 ```
 
+When the validator successfully verifies the block, it sends FF vote to the next N inturn validators.
+
 #### Transactions v1
-Protocol ID: `/bsc/vdn/v1/Transactions`
+Protocol ID: `/bsc/vdn/v1/transactions`
 
 Request Content:
 
 ```
 (
   txs: []Transaction // not exist 10MB in total msg size
-  timestamp: Time
 )
 ```
 
@@ -168,6 +189,8 @@ Response Content:
   code: StatusCode
 )
 ```
+
+When the validator receives the block, it sends the current pending txs to the next inturn validator.
 
 ## 4. Backwards Compatibility
 TBD

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -33,7 +33,7 @@ This is a new network topology that only accepts validators or nodes authorized 
 ## 2. Motivation
 - For low network latency between validators: as BSC targets to short its block interval to sub-second, it is quite crucial to reduce the network latency between validators. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots of network bandwidth and also cost non-negligible latency.
 - For MEV protection: validators are the key role in the network, it is reasonable that validators have the highest priority to get the transactions. Directed txpool means transactions would be forwarded to a small subset of validators that are most likely to produce the next block. It could avoid exposing users transactions directly to public txpool, so users would less likely to face malicious MEV attacks.
-For E2E latency: transaction latency is one of the key user experiences. Directed TxPool can accelerate transaction confirmation times while reducing the risk of malicious MEV attacks.
+- For low transaction latency: transaction latency is one of the key user experiences. Directed TxPool can provide a straight-forward path to deliver transactions to validators, whcih could be much faster comparing to the current gossip based public p2p network.
 ## 3. Specification
 ### 3.1.Validator Dedicated Network(VDN)
 The general network topology can be described by the following diagram:

--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -37,7 +37,7 @@ The general network layout is described in the bellow diagram, basically validat
 There would be some new roles in VDN:
 - VDN-BootNode: it helps validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
 - Validator: join the network through VDN-BootNode, discover and connect to other validators in VDN and exchange messages.
-- Validator-RPC-Sentry: transactions can be sent to this sentry node and it will forward it to the corresponding validator nodes.
+- Validator-Sentry(optional): it acts as the bridge between public network and validator. Transactions can be sent to this sentry node through RPC call or based current P2P protocol, then it will forward transactions to the corresponding validator nodes. It will also broadcast blocks produced by validators to public network. It is optional, validator can receive RPC call or P2P messages directly from public network, but the validator would have security risks. Validator can setup 1 or more sentry nodes, which could make it more robust. And validators can also share sentry nodes to save some resource cost.
 - Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.
 
 ![overview](./assets/BEP-525/3-1.png)


### PR DESCRIPTION
<pre>
  BEP: 525
  Title: Validator Dedicated Network And Directed TxPool
  Status: Draft
  Type: Standards
  Created: 2025-02-19
  Discussions(optional): https://forum.bnbchain.org/t/idea-faster-p2p-network-for-validators/3282
</pre>

# BEP-525: Validator Dedicated Network
- [BEP-525: Validator Dedicated Network](#bep-525-validator-dedicated-network)
  * [1. Summary](#1-summary)
  * [2. Motivation](#2-motivation)
  * [3. Specification](#3-specification)
    + [3.1.Validator Dedicated Network(VDN)](#31validator-dedicated-networkvdn)
    + [3.2.Directional Transactions Broadcast](#32directional-transactions-broadcast)
    + [3.3.Messages](#33messages)
      - [Handshake v1](#handshake-v1)
      - [ContactInfo v1](#contactinfo-v1)
      - [Block v1](#block-v1)
      - [RequestBlockByRange v1](#requestblockbyrange-v1)
      - [Vote v1](#vote-v1)
      - [Transactions v1](#transactions-v1)
  * [4. Backwards Compatibility](#4-backwards-compatibility)
  * [5. License](#5-license)

## 1. Summary
Add a network layer, which accept validator or validator authorized node to join in to improve the network efficiency and reduce network latency between validators.

## 2. Motivation
Low latency is one of the key user experience and if BSC wanna to support shorter block interval, network latency between validators could be crucial to support sub-second block interval. Current P2P gossip based network is good at broadcasting blocks/transactions to the whole network, but it is not efficient enough, i.e. it would take lots network bandwidth and also cost non-negligible latency. Validators are the key player to sustain the network, so one validator dedicated network layer could help to address the two issues.

## 3. Specification
### 3.1.Validator Dedicated Network(VDN)
The general network layout is described in the bellow diagram, basically validators would be able to be connected directly, so the latency can be reduced. 

There would be some new roles in VDN:
- BootNode: it is help validators to discover each other and establish the connection, and only validators registered with the staking contract are allowed to connect.
  - Validator Node: join the network through bootnode, discover all validators in the network, connect to active validator nodes, and exchange messages.
  - Validator-RPC-Sentry: transactions can be sent to this sentry node and it will forward it to the corresponding validator nodes.
  - Validator-Proxy: in is optional, in case validator don’t wanna expose itself to public network, it could authoerise one or more proxy nodes to connect to the VDN.

<img width="1088" alt="3-1" src="https://github.com/user-attachments/assets/71c9b2a8-d24e-400a-bbda-5deedb3ae52e" />

### 3.2.Directional Transactions Broadcast
It is another key aspect of VDN, transactions that are broadcasted in VDN would no long gossip based, on the opposite, they will only be broadcasted to nextN validators which have the right to propose next block.

In order to receive transactions from SentryProxy or RPC Provider, the sender needs to implement a batch send transaction. This can be done by using JSON-RPC batch request implementation with `eth_sendRawTransaction`. The receiver only receives transactions in batches and must not package the incoming transactions as a bundler.

### 3.3.Messages

It is recommended to use the QUIC protocol to send messages and broadcast messages based on the pubsub mechanism. All messages are `RLP encoded`.

#### Handshake v1
Protocol ID: `/bsc/vdn/v1/handshake`

Request & Response Content:

```
(
  chainID: uint64
  forkID: [4]byte
  genesis_hash: Hash
  node_version: string
  extend: []byte
  pub_key: PublicKey
  sign: Signature
)
```

Node must check `chainID`, `forkID`, `genesis_hash`, and `extend` is empty now. Only validators registered with the staking contract are allowed to connect.

Once the validator connects to any node, it will initiate a handshake. If the verification fails, it will disconnect.

After the connection is successful, it will periodically send handshakes. Once it finds that the validator is no longer active, it will disconnect.

#### ContactInfo v1
Protocol ID: `/bsc/vdn/v1/contact_info`

Request Content:

```
(
  peer_id: string
  pub_key: PublicKey
  listen_p2p_addrs: []Address // validator can connect it by the addresses.
  listen_tx_addrs: []Address // RPC provider or Sentry Proxy can batch send txs by the urls.
  cache: []Concact // max 8 cache node's contact
  create_time: Time
)
```

Response Content:

```
(
  code: StatusCode
)
```

After the validator joins the network, it will periodically send its contact info to the network. 

Once it connects to most nodes, it will reduce the sending frequency.

#### Block v1
Protocol ID: `/bsc/vdn/v1/block`

Request Content:

```
(
  block: Block
  create_time: Time
)
```

Response Content:

```
(
  code: StatusCode
)
```

After the inturn validator packs a block, it will immediately send the block to the next N inturn validators.

> N refers to the number of validators that produce blocks in the current epoch.

#### RequestBlockByRange v1
Protocol ID: `/bsc/vdn/v1/req/block_by_range`

Request Content:

```
(
  start_height: uint64
  count: uint64
)
```

Response Content:

```
(
  code: StatusCode
  blocks: []Block
)
```

When the validator receives the future block, it requests the missing block from the source node.

#### Vote v1
Protocol ID: `/bsc/vdn/v1/vote`

Request Content:

```
(
  vote: Vote
  create_time: Time
)
```

Response Content:

```
(
  code: StatusCode
)
```

When the validator successfully verifies the block, it sends FF vote to the next N inturn validators.

#### Transactions v1
Protocol ID: `/bsc/vdn/v1/transactions`

Request Content:

```
(
  txs: []Transaction // not exceed 10MB in total msg size
)
```

Response Content:

```
(
  code: StatusCode
)
```

When the validator receives the block, it sends the current pending txs to the next inturn validator.

## 4. Backwards Compatibility
TBD

## 5. License
The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
