### PR TITLE
update BEP-520: add two backward compatibility

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -82,7 +82,7 @@ This behavior needs to be penalized. In a continuous block production scenario, 
 The detection condition is as follows:
 ```Go
 // blockInterval     = time.Duration(1500)*time.Millisecond
-func (p *Parlia) isBlockDelayMinedOnPurpose(header, parent *types.Header) {
+func (p *Parlia) isBlockDelayMinedOnPurpose(header, parent *types.Header) bool {
 	return header.Difficulty == diffInTurn && parent.Difficulty == diffInTurn &&
 		header.Coinbase == parent.Coinbase &&
 		parent.MilliTimestamp()+blockInterval < header.MilliTimestamp()

--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -28,9 +28,8 @@
     - [6.1 MEV](#61-mev)
     - [6.2 Layer 2 Solutions](#62-layer-2-solutions)
     - [6.3 Quarterly Auto-Burn](#63-quarterly-auto-burn)
-    - [6.4 Timing Based on Block Numbers](#64-timing-based-on-block-numbers)
-    - [6.5 Indexing Based on `block.timestamp`](#65-indexing-based-on-blocktimestamp)
-    - [6.6 Block Finality](#66-block-finality)
+    - [6.4.DApp Developers And Users](#64dapp-developers-and-users)
+    - [6.5 Block Finality](#65-block-finality)
   - [7. License](#7-license)
 
 ## 1. Summary
@@ -154,13 +153,14 @@ The [Quarterly Auto-Burn](https://www.bnbburn.info/) mechanism also requires adj
 </div>
 where T represents the number of seconds in the corresponding quarter.
 
-### 6.4 Timing Based on Block Numbers
+### 6.4.DApp Developers And Users
+**Timing Based on Block Numbers**
 The reduction in block intervals affects logic that relies on block numbers for timing, whether in independent services or within smart contracts. A simple solution is to adjust the corresponding block count or avoid using block numbers for timing altogether.
 
-### 6.5 Indexing Based on `block.timestamp`
+**Indexing Based on `block.timestamp`**
 With the block interval reduced to 0.75 seconds, `block.timestamp`, which has second-level precision, may be the same for consecutive blocks. Therefore, using `block.timestamp` as an index key or for similar purposes requires adjustment. A common solution is to use the block hash instead.
 
-### 6.6 Block Finality
+### 6.5 Block Finality
 This BEP will not change the fast finality mechanism, but short block interval could bring some challenges to fast finality, as votes need to be propagated in a shorter time. When fast finality works properly, with this BEP, the average transaction finality time would be reduced from 7.5 seconds to 3.75 seconds.
 But if fast finality failed, with TurnLength 16 and ValidatorSize 21, for natural block finality, it will be:
 - (with >1/2 validator confirmations):  176(11*16) blocks, that is 264 seconds

--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -28,7 +28,9 @@
     - [6.1 MEV](#61-mev)
     - [6.2 Layer 2 Solutions](#62-layer-2-solutions)
     - [6.3 Quarterly Auto-Burn](#63-quarterly-auto-burn)
-    - [6.4 Block Finality](#64-block-finality)
+    - [6.4 Timing Based on Block Numbers](#64-timing-based-on-block-numbers)
+    - [6.5 Indexing Based on `block.timestamp`](#65-indexing-based-on-blocktimestamp)
+    - [6.6 Block Finality](#66-block-finality)
   - [7. License](#7-license)
 
 ## 1. Summary
@@ -152,7 +154,13 @@ The [Quarterly Auto-Burn](https://www.bnbburn.info/) mechanism also requires adj
 </div>
 where T represents the number of seconds in the corresponding quarter.
 
-### 6.4 Block Finality
+### 6.4 Timing Based on Block Numbers
+The reduction in block intervals affects logic that relies on block numbers for timing, whether in independent services or within smart contracts. A simple solution is to adjust the corresponding block count or avoid using block numbers for timing altogether.
+
+### 6.5 Indexing Based on `block.timestamp`
+With the block interval reduced to 0.75 seconds, `block.timestamp`, which has second-level precision, may be the same for consecutive blocks. Therefore, using `block.timestamp` as an index key or for similar purposes requires adjustment. A common solution is to use the block hash instead.
+
+### 6.6 Block Finality
 This BEP will not change the fast finality mechanism, but short block interval could bring some challenges to fast finality, as votes need to be propagated in a shorter time. When fast finality works properly, with this BEP, the average transaction finality time would be reduced from 7.5 seconds to 3.75 seconds.
 But if fast finality failed, with TurnLength 16 and ValidatorSize 21, for natural block finality, it will be:
 - (with >1/2 validator confirmations):  176(11*16) blocks, that is 264 seconds


### PR DESCRIPTION
add description for two cases about `Backward Compatibility`
1. Timing Based on Block Numbers
2. Indexing Based on `block.timestamp`