### PR TITLE
update BEP-520: fix contract parameter change target

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -111,9 +111,9 @@ A multitude of system parameters are configured based on the assumption that the
 |BSCGovernor.votingDelay  |contract parameter |$votingDelay |$votingDelay × 2  |$votingDelay × 4|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
-|BSCValidatorSet.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|
-|BSCValidatorSet.felonyThreshold  |contract parameter |$felonyThreshold  |$felonyThreshold × 2  |$felonyThreshold × 4|
-|BSCValidatorSet.felonySlashScope |contract parameter |$felonySlashScope  |$felonySlashScope × 2 |$felonySlashScope × 4|
+|SlashIndicator.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|
+|SlashIndicator.felonyThreshold  |contract parameter |$felonyThreshold  |$felonyThreshold × 2  |$felonyThreshold × 4|
+|SlashIndicator.felonySlashScope |contract parameter |$felonySlashScope  |$felonySlashScope × 2 |$felonySlashScope × 4|
 |BSCValidatorSet.TurnLength  |contract parameter |4  |16  |32|
 ## 5. Rational
 ### 5.1 Epoch and TurnLength


### PR DESCRIPTION
update BEP-520: fix contract parameter change target:
 misdemeanorThreshold, felonyThreshold and felonySlashScope, these 3 parameter belong to system contract `SlashIndicator`, not `BSCValidatorSet `