### PR TITLE
BEP-520 & BEP-524: reduce epoch length and turn length

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -103,7 +103,7 @@ As mentioned above, phase one and phase two are highly relevant, their parameter
 A multitude of system parameters are configured based on the assumption that the default block interval is 3 seconds. Consequently, when the block interval is altered, these parameters must be adjusted accordingly:
 |parameter |type |origin(3s)  | phase one(1.5s) | phase two(0.75s)|
 |--------|--------|--------|--------|--------|
-|Epoch  |client parameter |200  |1000 |2000|
+|Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |60M |30M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
 |Blob Target  |client parameter |3  |2  |1|
@@ -114,7 +114,7 @@ A multitude of system parameters are configured based on the assumption that the
 |SlashIndicator.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|
 |SlashIndicator.felonyThreshold  |contract parameter |$felonyThreshold  |$felonyThreshold × 2  |$felonyThreshold × 4|
 |SlashIndicator.felonySlashScope |contract parameter |$felonySlashScope  |$felonySlashScope × 2 |$felonySlashScope × 4|
-|BSCValidatorSet.TurnLength  |contract parameter |4  |16  |32|
+|BSCValidatorSet.TurnLength  |contract parameter |4  |8  |16|
 ## 5. Rational
 ### 5.1 Epoch and TurnLength
 Within an epoch, some validators may fail to produce blocks as scheduled due to maintenance, system failures, or other issues. This can lead to an increased number of low-difficulty blocks, reducing network stability. When a new epoch begins, the validator set is adjusted, replacing validators that have repeatedly failed to produce blocks as scheduled to maintain network stability. Therefore, the epoch duration must not be too long, or the network’s stability will degrade.
@@ -123,7 +123,7 @@ Since validators now produce blocks consecutively, the epoch length should be se
 
 At validator set transition points, a validator can deliberately delay broadcasting its block. As long as the delay does not exceed the predefined `initialBackOffTime`, the delayed block will still be accepted by the network. Increasing `BSCValidatorSet.TurnLength` effectively mitigates this issue.
 
-Considering these factors, the epoch length is set to 2000, and `TurnLength` to 32. When the block interval is ultimately reduced to 0.75 seconds, the epoch duration will increase from 600 to 1500 seconds. A 2000-block epoch roughly allows 21 validators to produce three full rounds of 32 blocks each.
+Considering these factors, the epoch length is set to 500, and `TurnLength` to 8. When the block interval is reduced to 1.5 seconds, the epoch duration will increase from 600 to 750 seconds. A 500-block epoch roughly allows 21 validators to produce three full rounds of 8 blocks each.
 
 ### 5.2 GasLimit and GasLimitBoundDivisor
 As the block interval shortens, the gas limit per block must decrease accordingly. However, since not all time within a block interval is used for transaction processing, the gas limit is reduced slightly more than the proportional decrease in block interval. The gas limit is initially set to decrease to 60M in the phase one hard fork and to 30M in phase two hard fork.
@@ -140,7 +140,7 @@ The six parameters—`BSCGovernor.votingPeriod`, `BSCGovernor.minPeriodAfterQuor
 
 ## 6. Backward Compatibility
 ### 6.1 MEV
-After phase one, the block interval will be reduced to 1.5 seconds, a single validator will produce 16 consecutive blocks per turn, keeping the total block production time at 24 seconds (1.5 × 16). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
+After phase one, the block interval will be reduced to 1.5 seconds, a single validator will produce 8 consecutive blocks per turn, keeping the total block production time at 12 seconds (1.5 × 8). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
 
 ### 6.2 Layer 2 Solutions
 The usage of blob transaction will be changed, as blob target will be decreased from 3 to 2 and blob maximum will be decreased from 6 to 3. Layer 2 can only attach 3 blobs at most for each transaction and the blob gas price calculation mechanism will also be slightly different.
@@ -161,9 +161,9 @@ With the block interval reduced to 0.75 seconds, `block.timestamp`, which has se
 
 ### 6.5 Block Finality
 This BEP will not change the fast finality mechanism, but short block interval could bring some challenges to fast finality, as votes need to be propagated in a shorter time. When fast finality works properly, with this BEP, the average transaction finality time would be reduced from 7.5 seconds to 3.75 seconds.
-But if fast finality failed, with TurnLength 16 and ValidatorSize 21, for natural block finality, it will be:
-- (with >1/2 validator confirmations):  176(11*16) blocks, that is 264 seconds
-- (with >2/3 validator confirmations):  240(15*16) blocks, that is 360 seconds
+But if fast finality failed, with TurnLength 8 and ValidatorSize 21, for natural block finality, it will be:
+- (with >1/2 validator confirmations):  88(11*8) blocks, that is 132 seconds
+- (with >2/3 validator confirmations):  120(15*8) blocks, that is 180 seconds
 
 ## 7. License
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEPs/BEP-524.md
+++ b/BEPs/BEP-524.md
@@ -42,7 +42,7 @@ As mentioned above, phase one and phase two are highly relevant, their parameter
 A multitude of system parameters are configured based on the assumption of the default block interval. Consequently, when the block interval is altered, these parameters must be adjusted accordingly:
 |parameter |type | origin(3s)  | phase one(1.5s) | phase two(0.75s)|
 |--------|--------|--------|--------|--------|
-|Epoch  |client parameter |200  |1000 |2000|
+|Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |60M |30M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
 |Blob Target  |client parameter |3  |2  |1|
@@ -53,14 +53,14 @@ A multitude of system parameters are configured based on the assumption of the d
 |BSCValidatorSet.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|
 |BSCValidatorSet.felonyThreshold  |contract parameter |$felonyThreshold  |$felonyThreshold × 2  |$felonyThreshold × 4|
 |BSCValidatorSet.felonySlashScope |contract parameter |$felonySlashScope  |$felonySlashScope × 2 |$felonySlashScope × 4|
-|BSCValidatorSet.TurnLength  |contract parameter |4  |16  |32|
+|BSCValidatorSet.TurnLength  |contract parameter |4  |8  |16|
 
 ## 5. Rational
 Refer BEP-520
 
 ## 6. Backward Compatibility
 ### 6.1 MEV
-After phase two, the block interval will be reduced to 0.75 seconds, a single validator will produce 32 consecutive blocks per turn, keeping the total block production time at 24 seconds (0.75 × 32). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
+After phase two, the block interval will be reduced to 0.75 seconds, a single validator will produce 16 consecutive blocks per turn, keeping the total block production time at 12 seconds (0.75 × 16). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
 
 ### 6.2 Layer 2 Solutions
 Similar to BEP-520, Layer 2 can only attach 2 blobs at most for each transaction and the blob gas price calculation mechanism will also be slightly different.
@@ -70,9 +70,9 @@ TBD
 
 ### 6.4 Block Finality
 This BEP will not change the fast finality mechanism, but short block interval could bring some challenges to fast finality, as votes need to be propagated in a shorter time. When fast finality works properly, with this BEP, the average transaction finality time would be reduced from 3.75 seconds to 1.875 seconds.
-But if fast finality failed, with TurnLength 32 and ValidatorSize 21, for natural block finality, it will be:
-- (with >1/2 validator confirmations):  352(11*32) blocks, that is 264 seconds
-- (with >2/3 validator confirmations):  480(15*32) blocks, that is 360 seconds
+But if fast finality failed, with TurnLength 16 and ValidatorSize 21, for natural block finality, it will be:
+- (with >1/2 validator confirmations):  176(11*16) blocks, that is 132 seconds
+- (with >2/3 validator confirmations):  240(15*16) blocks, that is 180 seconds
 
 ## 7. License
 The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
After communicating with the community, it was found that producing 16 consecutive blocks with a 1.5-second block interval extends the duration a validator can continuously control block production, which may worsen the MEV issue.

This PR modifies the turnLength so that after the hard fork, the duration a validator can continuously control block production remains at 12 seconds.

Additionally, the epoch was originally set to a larger value to ensure fair block production rights among validators within an epoch. After reducing turnLength, the epoch is also shortened accordingly, while validators' block production rights remain unchanged.