### PR TITLE
BEP-520 & BEP-524: no need to change votingDelay

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -109,7 +109,6 @@ A multitude of system parameters are configured based on the assumption that the
 |Blob Target  |client parameter |3  |2  |1|
 |Blob Maximum |client parameter |6  |3  |2|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
-|BSCGovernor.votingDelay  |contract parameter |$votingDelay |$votingDelay × 2  |$votingDelay × 4|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
 |SlashIndicator.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|
@@ -137,7 +136,7 @@ As GasLimit is not part of consensus, it is calculated based on validators' conf
 This BEP implementation aims to maintain or enhance the network’s capacity to handle blobs. According to the table, before phase one hard fork, the network handles a target of 1 blob per second (3 blobs/3 seconds). After phase one hard fork, it will be 4/3 blobs per second(2 blobs/1.5seconds). So there will be ~33% improvement in blob processing capacity.
 
 ### 5.4 Contract Parameters
-The seven parameters—`BSCGovernor.votingDelay`, `BSCGovernor.votingPeriod`, `BSCGovernor.minPeriodAfterQuorum`, `BSCValidatorSet.misdemeanorThreshold`, `BSCValidatorSet.felonyThreshold`, `BSCValidatorSet.felonySlashScope`, and `Blob MinBlocksForBlobRequests`—are all measured in block numbers and used to calculate time. Therefore, when the block interval is reduced, the block numbers must be increased proportionally to maintain the same time representation.
+The six parameters—`BSCGovernor.votingPeriod`, `BSCGovernor.minPeriodAfterQuorum`, `BSCValidatorSet.misdemeanorThreshold`, `BSCValidatorSet.felonyThreshold`, `BSCValidatorSet.felonySlashScope`, and `Blob MinBlocksForBlobRequests`—are all measured in block numbers and used to calculate time. Therefore, when the block interval is reduced, the block numbers must be increased proportionally to maintain the same time representation.
 
 ## 6. Backward Compatibility
 ### 6.1 MEV

--- a/BEPs/BEP-524.md
+++ b/BEPs/BEP-524.md
@@ -48,7 +48,6 @@ A multitude of system parameters are configured based on the assumption of the d
 |Blob Target  |client parameter |3  |2  |1|
 |Blob Maximum |client parameter |6  |3  |2|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
-|BSCGovernor.votingDelay  |contract parameter |$votingDelay |$votingDelay × 2  |$votingDelay × 4|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
 |BSCValidatorSet.misdemeanorThreshold |contract parameter |$misdemeanorThreshold  |$misdemeanorThreshold × 2 |$misdemeanorThreshold × 4|


### PR DESCRIPTION
votingDelay is 0 in bsc mainnet and chapel net , so no need to change.
https://bscscan.com/address/0x0000000000000000000000000000000000002004#readContract
https://testnet.bscscan.com/address/0x0000000000000000000000000000000000002004#readContract