### PR TITLE
BEP-520: recover initialBackOffTime and increments the slash count when block delay mined on purpose

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -16,7 +16,6 @@
     - [4.1 Parlia Changes](#41-parlia-changes)
       - [4.1.1 Millisecond Representation in Block Header](#411-millisecond-representation-in-block-header)
       - [4.1.2 Penalize Intentional Delay Block Production](#412-penalize-intentional-delay-block-production)
-      - [4.1.3 Increase `initialBackOffTime`](#413-increase-initialbackofftime)
     - [4.2 Parameter Changes](#42-parameter-changes)
       - [4.2.1 Change table](#421-change-table)
   - [5. Rational](#5-rational)
@@ -77,7 +76,7 @@ Current settings:
 ```
 The in-turn validator can delay block production to just below `initialBackOffTime` without worrying about competition from the second-priority validator. As the block interval decreases, the proportion of production time that the in-turn validator can unfairly "steal" increases.
 
-This behavior needs to be penalized. In a continuous block production scenario, such cases are easy to identify. The penalty mechanism reallocates all transaction fee rewards (except the portion that is burned) to the `SystemRewardContract`.
+This behavior needs to be penalized. In a continuous block production scenario, such cases are easy to identify. The penalty mechanism reallocates all transaction fee rewards (except the portion that is burned) to the `SystemRewardContract` and increments the slash count by 1.
 
 The detection condition is as follows:
 ```Go
@@ -87,13 +86,6 @@ func (p *Parlia) isBlockDelayMinedOnPurpose(header, parent *types.Header) bool {
 		header.Coinbase == parent.Coinbase &&
 		parent.MilliTimestamp()+blockInterval < header.MilliTimestamp()
 }
-```
-
-#### 4.1.3 Increase `initialBackOffTime`
-As the block interval decreases, blocks may fail to propagate in time, increasing the likelihood that a secondary validator will produce and propagate a block, which in turn raises the risk of potential block reorganizations across nodes.
-Given the above penalty mechanism, we can now safely increase the `initialBackOffTime` to 2 seconds to reduce the likelihood of block reorganization:
-```Go
-  newInitialBackOffTime= time.Duration(2)*time.Second
 ```
 
 ### 4.2 Parameter Changes


### PR DESCRIPTION
1. As the ratio `initialBackOffTime/blockInterval` increases, validators are more likely to delay block time or delay block broadcast. Therefore, restore the initialBackOffTime here.
2. Validators who intentionally delay block mining should be penalized the same way as those absent for in-turn mining.