### PR TITLE
BEP-520: increase initialBackOffTime and remove punish delay block production

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -15,7 +15,7 @@
   - [4. Specification](#4-specification)
     - [4.1 Parlia Changes](#41-parlia-changes)
       - [4.1.1 Millisecond Representation in Block Header](#411-millisecond-representation-in-block-header)
-      - [4.1.2 Penalize Intentional Delay Block Production](#412-penalize-intentional-delay-block-production)
+      - [4.1.2 Increase `initialBackOffTime`](#412-increase-initialbackofftime)
     - [4.2 Parameter Changes](#42-parameter-changes)
       - [4.2.1 Change table](#421-change-table)
   - [5. Rational](#5-rational)
@@ -68,24 +68,15 @@ func (h *Header) MilliTimestamp() uint64 {
 }
 ```
 
-#### 4.1.2 Penalize Intentional Delay Block Production
+#### 4.1.2 Increase `initialBackOffTime`
 In the Parlia engine, each block height has a designated in-turn validator responsible for producing the block. If the in-turn validator fails to produce the block in time, a second-priority validator will take over after a delay equal to `initialBackOffTime`.
 Current settings:
 ```Go
   initialBackOffTime= time.Duration(1)*time.Second
 ```
-The in-turn validator can delay block production to just below `initialBackOffTime` without worrying about competition from the second-priority validator. As the block interval decreases, the proportion of production time that the in-turn validator can unfairly "steal" increases.
-
-This behavior needs to be penalized. In a continuous block production scenario, such cases are easy to identify. The penalty mechanism reallocates all transaction fee rewards (except the portion that is burned) to the `SystemRewardContract` and increments the slash count by 1.
-
-The detection condition is as follows:
+As the block interval decreases, delayed block propagation will result in more blocks being reorganized each time. To mitigate this issue, the `initialBackOffTime` is set to 2 seconds.
 ```Go
-// blockInterval     = time.Duration(1500)*time.Millisecond
-func (p *Parlia) isBlockDelayMinedOnPurpose(header, parent *types.Header) bool {
-	return header.Difficulty == diffInTurn && parent.Difficulty == diffInTurn &&
-		header.Coinbase == parent.Coinbase &&
-		parent.MilliTimestamp()+blockInterval < header.MilliTimestamp()
-}
+  newInitialBackOffTime= time.Duration(2)*time.Second
 ```
 
 ### 4.2 Parameter Changes


### PR DESCRIPTION
Two updates to BEP-520:
- Increase **initialBackOffTime** from 1 second to 2 seconds
As the block interval decreases, delayed block propagation will lead to more blocks being reorganized each time. To mitigate this, set initialBackOffTime to 2 seconds. It may have some side-effects, especially it encourages "delay broadcast", but at the moment reorg is more crucial to user experience and we can do more research to better address the "delay broadcast" issue.

- remove punish delay block production
The **Intentional Delay Block Production** can be detected easily without this penalty mechanism, would prefer not to add this penalty mechanism at the moment as "delay broadcast" is quite a big topic and need more community discussion to get a more acceptable solution.