### PR TITLE
BEP-520 & BEP-524: not change Blob Target and Blob Maximum in the first phase

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -98,8 +98,8 @@ A multitude of system parameters are configured based on the assumption that the
 |Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |60M |30M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
-|Blob Target  |client parameter |3  |2  |1|
-|Blob Maximum |client parameter |6  |3  |2|
+|Blob Target  |client parameter |3  |3  |1|
+|Blob Maximum |client parameter |6  |6  |2|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
@@ -125,7 +125,7 @@ GasLimitBoundDivisor represents the rate of change in GasLimit. Since the block 
 As GasLimit is not part of consensus, it is calculated based on validators' configuration. So need validators's support to downgrade their gas limit configuration before each hard fork.
 
 ### 5.3 Blob Related
-This BEP implementation aims to maintain or enhance the network’s capacity to handle blobs. According to the table, before phase one hard fork, the network handles a target of 1 blob per second (3 blobs/3 seconds). After phase one hard fork, it will be 4/3 blobs per second(2 blobs/1.5seconds). So there will be ~33% improvement in blob processing capacity.
+This BEP implementation aims to maintain or enhance the network’s capacity to handle blobs. According to the table, before phase one hard fork, the network handles a target of 1 blob per second (3 blobs/3 seconds). After phase one hard fork, it will be 2 blobs per second(3 blobs/1.5seconds). So there will be 100% improvement in blob processing capacity.
 
 ### 5.4 Contract Parameters
 The six parameters—`BSCGovernor.votingPeriod`, `BSCGovernor.minPeriodAfterQuorum`, `BSCValidatorSet.misdemeanorThreshold`, `BSCValidatorSet.felonyThreshold`, `BSCValidatorSet.felonySlashScope`, and `Blob MinBlocksForBlobRequests`—are all measured in block numbers and used to calculate time. Therefore, when the block interval is reduced, the block numbers must be increased proportionally to maintain the same time representation.
@@ -135,7 +135,7 @@ The six parameters—`BSCGovernor.votingPeriod`, `BSCGovernor.minPeriodAfterQuor
 After phase one, the block interval will be reduced to 1.5 seconds, a single validator will produce 8 consecutive blocks per turn, keeping the total block production time at 12 seconds (1.5 × 8). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
 
 ### 6.2 Layer 2 Solutions
-The usage of blob transaction will be changed, as blob target will be decreased from 3 to 2 and blob maximum will be decreased from 6 to 3. Layer 2 can only attach 3 blobs at most for each transaction and the blob gas price calculation mechanism will also be slightly different.
+In the first phase, `Blob Target` and `Blob Maximum` will not be reduced to avoid impacting existing users.
 
 ### 6.3 Quarterly Auto-Burn
 The [Quarterly Auto-Burn](https://www.bnbburn.info/) mechanism also requires adjustment,The block count in the formula is replaced with time, resulting in the new formula:

--- a/BEPs/BEP-524.md
+++ b/BEPs/BEP-524.md
@@ -45,8 +45,8 @@ A multitude of system parameters are configured based on the assumption of the d
 |Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |60M |30M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
-|Blob Target  |client parameter |3  |2  |1|
-|Blob Maximum |client parameter |6  |3  |2|
+|Blob Target  |client parameter |3  |3  |1|
+|Blob Maximum |client parameter |6  |6  |2|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
@@ -63,7 +63,8 @@ Refer BEP-520
 After phase two, the block interval will be reduced to 0.75 seconds, a single validator will produce 16 consecutive blocks per turn, keeping the total block production time at 12 seconds (0.75 × 16). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
 
 ### 6.2 Layer 2 Solutions
-Similar to BEP-520, Layer 2 can only attach 2 blobs at most for each transaction and the blob gas price calculation mechanism will also be slightly different.
+Layer 2 may be limited to attaching a maximum of 2 blobs per transaction. The final values for  `Blob Target` and `Blob Maximum` may be adjusted following thorough discussions with the community.
+
 
 ### 6.3 Quarterly Auto-Burn
 TBD


### PR DESCRIPTION
In the first phase, `Blob Target` and `Blob Maximum` will not be reduced to avoid impacting existing users. 
The final values for  these two values in the second phase may be changed after thorough discussions with the community.