### PR TITLE
BEP-520: change gaslimit to 70M from 60M

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -87,7 +87,7 @@ A multitude of system parameters are configured based on the assumption that the
 |parameter |type |origin(3s)  | phase one(1.5s) | phase two(0.75s)|
 |--------|--------|--------|--------|--------|
 |Epoch  |client parameter |200  |500 |1000|
-|GasLimit |client parameter |140M |60M |30M|
+|GasLimit |client parameter |140M |70M |35M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
 |Blob Target  |client parameter |3  |3  |1|
 |Blob Maximum |client parameter |6  |6  |2|
@@ -109,7 +109,7 @@ At validator set transition points, a validator can deliberately delay broadcast
 Considering these factors, the epoch length is set to 500, and `TurnLength` to 8. When the block interval is reduced to 1.5 seconds, the epoch duration will increase from 600 to 750 seconds. A 500-block epoch roughly allows 21 validators to produce three full rounds of 8 blocks each.
 
 ### 5.2 GasLimit and GasLimitBoundDivisor
-As the block interval shortens, the gas limit per block must decrease accordingly. However, since not all time within a block interval is used for transaction processing, the gas limit is reduced slightly more than the proportional decrease in block interval. The gas limit is initially set to decrease to 60M in the phase one hard fork and to 30M in phase two hard fork.
+As the block interval shortens, the gas limit per block must decrease accordingly. The gas limit is initially set to decrease to 70M in the phase one hard fork and to 35M in phase two hard fork.
 
 GasLimitBoundDivisor represents the rate of change in GasLimit. Since the block interval will be reduced by a factor of four after phase two, GasLimitBoundDivisor is increased by the same factor to maintain a consistent rate of GasLimit adjustment to avoid sharp gas limit fluctuation if some validators use a too small or too large gas limit value.
 

--- a/BEPs/BEP-524.md
+++ b/BEPs/BEP-524.md
@@ -43,7 +43,7 @@ A multitude of system parameters are configured based on the assumption of the d
 |parameter |type | origin(3s)  | phase one(1.5s) | phase two(0.75s)|
 |--------|--------|--------|--------|--------|
 |Epoch  |client parameter |200  |500 |1000|
-|GasLimit |client parameter |140M |60M |30M|
+|GasLimit |client parameter |140M |70M |35M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
 |Blob Target  |client parameter |3  |3  |1|
 |Blob Maximum |client parameter |6  |6  |2|


### PR DESCRIPTION
BEP-520: change gaslimit to 70M from 60M

based on benchmark, when block interval reduced to 1.5s, network is stable with gaslimit set to 70M