### PR TITLE
BEP-524: not change max and target of blobs in every block

### DIFF
--- a/BEPs/BEP-524.md
+++ b/BEPs/BEP-524.md
@@ -48,8 +48,8 @@ A multitude of system parameters are configured based on the assumption of the d
 |Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |70M |35M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
-|Blob Target  |client parameter |3  |3  |1|
-|Blob Maximum |client parameter |6  |6  |2|
+|Blob Target  |client parameter |3  |3  |3|
+|Blob Maximum |client parameter |6  |6  |6|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |
@@ -89,7 +89,7 @@ This feature leverages Fast Finality to optimize the selection of block producer
 After phase two, the block interval will be reduced to 0.75 seconds, a single validator will produce 16 consecutive blocks per turn, keeping the total block production time at 12 seconds (0.75 × 16). However, the shorter block time significantly reduces the collaboration window for searchers, builders, and validators, impacting the current process and requiring adjustments.
 
 ### 6.2 Layer 2 Solutions
-Layer 2 may be limited to attaching a maximum of 2 blobs per transaction. The final values for  `Blob Target` and `Blob Maximum` may be adjusted following thorough discussions with the community.
+`Blob Target` and `Blob Maximum` remain unchanged to preserve compatibility with existing users. At the same time, the increased blob capacity lowers the cost of submitting blob data.
 
 
 ### 6.3 Quarterly Auto-Burn


### PR DESCRIPTION
`Blob Target` and `Blob Maximum` remain unchanged to preserve compatibility with existing users