### PR TITLE
Update BEP-520.md

### DIFF
--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -89,8 +89,8 @@ A multitude of system parameters are configured based on the assumption that the
 |Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |70M |35M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
-|Blob Target  |client parameter |3  |3  |1|
-|Blob Maximum |client parameter |6  |6  |2|
+|Blob Target  |client parameter |3  |3  |3|
+|Blob Maximum |client parameter |6  |6  |6|
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |

--- a/BEPs/BEP-520.md
+++ b/BEPs/BEP-520.md
@@ -89,8 +89,8 @@ A multitude of system parameters are configured based on the assumption that the
 |Epoch  |client parameter |200  |500 |1000|
 |GasLimit |client parameter |140M |70M |35M|
 |GasLimitBoundDivisor |client parameter |256 |1024 |1024|
-|Blob Target  |client parameter |3  |3  |3|
-|Blob Maximum |client parameter |6  |6  |6|
+|Blob Target  |client parameter |3  |3  |3  |
+|Blob Maximum |client parameter |6  |6  |6  |
 |Blob MinBlocksForBlobRequests  |client parameter |524288 |1048576 (524288 × 2) |2097152 (524288 × 4)|
 |BSCGovernor.votingPeriod |contract parameter |$votingPeriod  |$votingPeriod × 2 |$votingPeriod × 4|
 |BSCGovernor.minPeriodAfterQuorum |contract parameter |$minPeriodAfterQuorum  |$minPeriodAfterQuorum × 2 |$minPeriodAfterQuorum × 4 |


### PR DESCRIPTION
Update the phase2 parameter of blob target and maximum. In consideration of L2 backward compatibility, keep the blob limit unchanged.