### PR TITLE
readme: update status of 2 BEPs

### DIFF
--- a/BEPs/BEP-525.md
+++ b/BEPs/BEP-525.md
@@ -2,9 +2,9 @@
   BEP: 525
   Title: Validator Dedicated Network
   Status: Draft
-  Type: Standards
+  Type: Withdrawn
   Created: 2025-02-19
-  Discussions(optional): https://forum.bnbchain.org/t/idea-faster-p2p-network-for-validators/3282
+  Discussions(optional): https://forum.bnbchain.org/t/call-for-feedbacks-bsc-short-block-interval-validator-dedicated-network-and-direct-mempool/3348
 </pre>
 
 # BEP-525: Validator Dedicated Network

--- a/BEPs/BEP-536.md
+++ b/BEPs/BEP-536.md
@@ -1,10 +1,10 @@
 <pre>
   BEP: 536
   Title: Directed TxPool
-  Status: Draft
+  Status: Withdrawn
   Type: Standards
   Created: 2025-02-19
-  Discussions(optional): https://forum.bnbchain.org/t/idea-faster-p2p-network-for-validators/3282
+  Discussions(optional): https://forum.bnbchain.org/t/call-for-feedbacks-bsc-short-block-interval-validator-dedicated-network-and-direct-mempool/3348
 </pre>
 
 # BEP-536: Directed TxPool

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Here is the list of subjects of BEPs:
 | [BEP-496](./BEPs/BEP-496.md) | Implement EIP-7623: Increase calldata cost | Standards | Enabled |
 | [BEP-520](./BEPs/BEP-520.md) | Short Block Interval Phase One: 1.5 seconds | Standards | Enabled |
 | [BEP-524](./BEPs/BEP-524.md) | Short Block Interval Phase Two: 0.75 seconds | Standards | Draft |
+| [BEP-525](./BEPs/BEP-525.md) | Validator Dedicated Network | Standards | Withdrawn |
+| [BEP-536](./BEPs/BEP-536.md) | Directed TxPool | Standards | Withdrawn |
 
 
 # BNB Chain Upgrades


### PR DESCRIPTION
"BEP-536: Directed TxPool" was withdrawn due to:
  - the cons of the Directed TxPool discussed in forum

"BEP-525:Validator Dedicated Network" was withdrawn due to:
  - add extra complexity to validators
  - part of BEP-525 was to support BEP-536, but BEP-536 was withdrawn now
  - part of BEP-525 will be replaced by "BEP-563: Enhanced Validator Network"