### PR TITLE
BAP-578: Add SHLL Protocol as production reference implementation on BSC Mainnet

### DIFF
--- a/BAPs/BAP-578.md
+++ b/BAPs/BAP-578.md
@@ -574,6 +574,56 @@ The implementation includes:
 - Dual-path architecture supporting both simple and learning agents
 - Migration tools for upgrading simple agents to learning agents
 
+### Production Implementation: SHLL Protocol
+
+A production implementation deployed on BSC Mainnet is available at: https://github.com/kledx/shll
+
+SHLL extends BAP-578 with an on-chain policy enforcement layer, enabling autonomous AI agents to execute DeFi operations within cryptographically enforced safety boundaries.
+
+**BSC Mainnet Contracts (Chain ID: 56):**
+
+| Contract | Address | Purpose |
+|---|---|---|
+| AgentNFA (V4.1) | `0x71cE46099E4b2a2434111C009A7E9CFd69747c8E` | BAP-578 core: agent identity, metadata, lifecycle |
+| LearningModule | `0x019765B2669b1A3FfffE8213E9bd0b0D8eb00892` | §4.4 Learning module (Merkle tree) |
+| PolicyGuardV4 | `0x25d17eA0e3Bcb8CA08a2BFE917E817AFc05dbBB3` | §4.7 Security: composable policy validation |
+| ProtocolRegistry | `0x1A5EA54a3beaf4fba75f73581cf6A945746E6DF1` | Registered protocol management |
+| SpendingLimitPolicyV2 | `0x28efC8D513D44252EC26f710764ADe22b2569115` | Per-action/daily spending caps |
+| CooldownPolicy | `0x0E0B2006DE4d68543C4069249a075C215510efDB` | Minimum interval between actions |
+| ReceiverGuardPolicyV2 | `0x7A9618ec6c2e9D93712326a7797A829895c0AfF6` | Recipient address validation |
+| DeFiGuardPolicyV2 | `0xD1b6a97400Bc62ed6000714E9810F36Fc1a251f1` | DeFi function selector filtering |
+| DexWhitelistPolicy | `0x0D423290A050187AA15B7567aa9DB32535cEF8fb` | Trusted DEX router whitelist |
+| TokenWhitelistPolicy | `0x4300e2111DB1DB41d74C98fAde2DB432DceF4dBA` | Approved token whitelist |
+| ListingManagerV2 | `0x1f9CE85bD0FF75acc3D92eB79f1Eb472f0865071` | Agent template marketplace |
+| SubscriptionManager | `0x66487D5509005825C85EB3AAE06c3Ec443eF7359` | Subscription-based agent rental |
+
+**BAP-578 Specification Coverage:**
+
+| Section | Feature | Status |
+|---|---|---|
+| §4.1 | Core Interface (IBAP578) | ✅ Implemented |
+| §4.2 | Agent State Management | ✅ Implemented |
+| §4.3 | Enhanced Metadata Schema | ✅ Implemented |
+| §4.4 | Learning Module System | ✅ Implemented (Merkle tree) |
+| §4.5 | Memory Module Registry | 🔲 Planned |
+| §4.6 | Vault Permission System | ✅ Implemented (via AgentAccount) |
+| §4.7 | Security Mechanisms | ✅ Extended (6-module PolicyGuard) |
+| §4.8 | Agent Templates | ✅ Implemented (template/instance minting) |
+| §4.9 | Dual-Path Architecture | ✅ Implemented |
+
+**Additional Features:**
+- ERC-4907 integration for time-limited agent rental
+- ERC-8004 on-chain agent identity registration
+- ERC-6551 Token Bound Accounts for isolated agent vaults
+- npm package: [shll-skills](https://www.npmjs.com/package/shll-skills) (CLI + MCP Server)
+- 276/279 Foundry test cases passing
+- All contracts verified on [BscScan](https://bscscan.com/address/0x71cE46099E4b2a2434111C009A7E9CFd69747c8E)
+
+**Links:**
+- Repository: https://github.com/kledx/shll
+- Website: https://shll.run
+- npm: https://www.npmjs.com/package/shll-skills
+
 ## 9. Security Considerations
 
 ### 9.1 Smart Contract Security


### PR DESCRIPTION
Add SHLL Protocol (https://github.com/kledx/shll) as a production reference implementation of BAP-578 NFA on BSC Mainnet (Chain ID 56). SHLL is the first BAP-578 implementation deployed to BSC Mainnet with live agent accounts and real transaction execution. The implementation extends BAP-578 with a composable on-chain policy enforcement layer (PolicyGuard). Includes 12 verified mainnet contracts and 276/279 Foundry test cases passing.