### PR TITLE
BEP-667.md：update finality analysis

### DIFF
--- a/BEPs/BEP-667.md
+++ b/BEPs/BEP-667.md
@@ -111,30 +111,36 @@ From `N × BlockInterval > 2 × OWD + T_import`, the maximum T_import is `N × B
 
 Vote Interval applies the BEP-126 justify/finalize rules — refined by [BEP-648](./BEP-648.md) — to the voting block subsequence. A non-voting block is finalized together with the next voting block.
 
-Let `j = blockNumber mod N` be a block's position within the voting cycle. By Section 2's core constraint, ⅔+ attestation is gathered within `2·OWD + T_import < N·BI` after a voting block is produced. A voting block V[k] is finalized once V[k+1] is justified — one further voting interval plus another vote-gathering round:
+Let `j = blockNumber mod N` be a block's position within the voting cycle. By Section 2's core constraint, ⅔+ attestation is gathered within `2 × OWD + T_import < N × BI` after a voting block is produced. A voting block V[k] is finalized once V[k+1] is justified — one further voting interval plus another vote-gathering round:
 
 ```
-         ⎧ N·BI + (2·OWD + T_import)            if j = 0  (voting block)
+         ⎧ N × BI + (2 × OWD + T_import)            if j = 0  (voting block)
 L(j) =  ⎨
-         ⎩ (2N − j)·BI + (2·OWD + T_import)     if 1 ≤ j < N  (non-voting block)
+         ⎩ (2N − j) × BI + (2 × OWD + T_import)     if 1 ≤ j < N  (non-voting block)
 ```
 
-Without BEP-648, justification would wait for attestation inclusion in the next voting block's header and finality would be `2N·BI` / `(3N − j)·BI` respectively.
+Without BEP-648, justification would wait for attestation inclusion in the next voting block's header and finality would be `2N × BI` / `(3N − j) × BI` respectively.
 
 **Numerical comparison.** With `OWD ≈ 120ms` and `T_import` sized to saturate the voting window (Section 6):
 
-| BlockInterval | N | T_import | 2·OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
-|---------------|---|----------|------------------|--------------|-------------|---------|
-| 450ms         | 1 | 210ms    | 450ms            | 900ms        | —           | 900ms   |
-| 250ms         | 2 | 250ms    | 490ms            | 990ms        | 1240ms      | 1115ms  |
-| 100ms         | 3 | 60ms     | 300ms            | 600ms        | 800ms       | 700ms   |
+| BlockInterval | N | T_import | 2 × OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
+|---------------|---|----------|--------------------|--------------|-------------|---------|
+| 450ms         | 1 | 210ms    | 450ms              | 900ms        | —           | 900ms   |
+| 250ms         | 2 | 250ms    | 490ms              | 990ms        | 1240ms      | 1115ms  |
+| 100ms         | 3 | 60ms     | 300ms              | 600ms        | 800ms       | 700ms   |
 
-Vote Interval structurally trades finality latency for block throughput and for feasibility at block intervals below `2·OWD`:
+The above is a theoretical upper bound where `T_import` saturates the voting window. Vote Interval structurally trades finality latency for block throughput and for feasibility at block intervals below `2 × OWD`:
 
-- At `BI = 250ms, N = 2`, finality is ~1115ms average — modestly higher than today's 900ms, in exchange for 1.8× block rate and ~100% CPU utilization (up from 47%).
-- At `BI = 100ms, N = 3`, finality drops to ~700ms *and* block rate increases 4.5×; such block intervals are unreachable without Vote Interval (BEP-126 requires `BI > 2·OWD`).
+- At `BI = 250ms, N = 2`, saturated finality is ~1115ms average — modestly higher than today's 900ms, in exchange for 1.8× block rate and ~100% CPU utilization (up from 47%).
+- At `BI = 100ms, N = 3`, finality drops to ~700ms *and* block rate increases 4.5×; such block intervals are unreachable without Vote Interval (BEP-126 requires `BI > 2 × OWD`).
 
-Under lighter load, actual `T_import` is smaller than the saturated bound, pulling the vote-gathering term toward its floor of `2·OWD ≈ 240ms` and tightening finality accordingly (e.g. at `BI = 250ms, N = 2`: voting-block finality → 740ms, average → 865ms).
+**Practical scenario.** In current workloads, `T_import` is well below the saturated bound. At the current 50M gas limit, typical `T_import ≈ 100ms`, giving `2 × OWD + T_import ≈ 340ms`:
+
+| BlockInterval | N | 2 × OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
+|---------------|---|---------------------|--------------|-------------|---------|
+| 250ms         | 2 | 340ms               | 840ms        | 1090ms      | 965ms   |
+
+Voting-block finality (840ms) is faster than today's 900ms under `N = 1, BI = 450ms`, while block rate increases 1.8×.
 
 ## 8. Security
 
@@ -146,7 +152,7 @@ Block production liveness is unaffected: non-voting blocks do not require Fast F
 
 This BEP is **not backward compatible**. It changes the Fast Finality voting and aggregation rules, requiring a hard fork with coordinated client upgrades across all validators and full nodes.
 
-Finality latency changes from `2·BlockInterval` to `N·BI + (2·OWD + T_import)` for voting blocks and `(2N - j)·BI + (2·OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration, average finality rises to ~1115ms under saturated load (vs. today's 900ms) in exchange for 1.8× block rate and near-100% CPU utilization; under light load it drops toward ~865ms.
+Finality latency changes from `2 × BlockInterval` to `N × BI + (2 × OWD + T_import)` for voting blocks and `(2N - j) × BI + (2 × OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration with the current 50M gas limit (`T_import ≈ 100ms`), voting-block finality is ~840ms — faster than today's 900ms — with an average of ~965ms, while block rate increases 1.8×.
 
 ## 10. License
 

--- a/BEPs/BEP-667.md
+++ b/BEPs/BEP-667.md
@@ -109,23 +109,32 @@ From `N × BlockInterval > 2 × OWD + T_import`, the maximum T_import is `N × B
 
 ## 7. Finality Analysis
 
-Under Vote Interval, voting blocks and non-voting blocks have different finality latencies. Let `j = blockNumber mod N` denote a block's position within the voting cycle:
+Vote Interval applies the BEP-126 justify/finalize rules — refined by [BEP-648](./BEP-648.md) — to the voting block subsequence. A non-voting block is finalized together with the next voting block.
+
+Let `j = blockNumber mod N` be a block's position within the voting cycle. By Section 2's core constraint, ⅔+ attestation is gathered within `2·OWD + T_import < N·BI` after a voting block is produced. A voting block V[k] is finalized once V[k+1] is justified — one further voting interval plus another vote-gathering round:
 
 ```
-         ⎧ 2N × BI             if j = 0  (voting block)
+         ⎧ N·BI + (2·OWD + T_import)            if j = 0  (voting block)
 L(j) =  ⎨
-         ⎩ (3N - j) × BI       if 1 ≤ j < N  (non-voting block)
+         ⎩ (2N − j)·BI + (2·OWD + T_import)     if 1 ≤ j < N  (non-voting block)
 ```
 
-A voting block V[k] is finalized when both V[k] and V[k+1] are justified, requiring 2 voting-block intervals (`2N × BI`). A non-voting block at position j must wait for the next voting block V[k+1] to be finalized, adding up to `(N - j)` extra block intervals.
+Without BEP-648, justification would wait for attestation inclusion in the next voting block's header and finality would be `2N·BI` / `(3N − j)·BI` respectively.
 
-| N | Best (j=0) | Worst (j=1) | Average |
-|---|------------|-------------|---------|
-| 1 | 2 BI | 2 BI | 2 BI |
-| 2 | 4 BI | 5 BI | 4.5 BI |
-| 3 | 6 BI | 8 BI | 7 BI |
+**Numerical comparison.** With `OWD ≈ 120ms` and `T_import` sized to saturate the voting window (Section 6):
 
-With `N = 2` and `BlockInterval = 250ms`, the finality range is 1000–1250ms (average 1125ms), compared to 900ms under the current `N = 1` at 450ms.
+| BlockInterval | N | T_import | 2·OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
+|---------------|---|----------|------------------|--------------|-------------|---------|
+| 450ms         | 1 | 210ms    | 450ms            | 900ms        | —           | 900ms   |
+| 250ms         | 2 | 250ms    | 490ms            | 990ms        | 1240ms      | 1115ms  |
+| 100ms         | 3 | 60ms     | 300ms            | 600ms        | 800ms       | 700ms   |
+
+Vote Interval structurally trades finality latency for block throughput and for feasibility at block intervals below `2·OWD`:
+
+- At `BI = 250ms, N = 2`, finality is ~1115ms average — modestly higher than today's 900ms, in exchange for 1.8× block rate and ~100% CPU utilization (up from 47%).
+- At `BI = 100ms, N = 3`, finality drops to ~700ms *and* block rate increases 4.5×; such block intervals are unreachable without Vote Interval (BEP-126 requires `BI > 2·OWD`).
+
+Under lighter load, actual `T_import` is smaller than the saturated bound, pulling the vote-gathering term toward its floor of `2·OWD ≈ 240ms` and tightening finality accordingly (e.g. at `BI = 250ms, N = 2`: voting-block finality → 740ms, average → 865ms).
 
 ## 8. Security
 
@@ -137,7 +146,7 @@ Block production liveness is unaffected: non-voting blocks do not require Fast F
 
 This BEP is **not backward compatible**. It changes the Fast Finality voting and aggregation rules, requiring a hard fork with coordinated client upgrades across all validators and full nodes.
 
-Finality latency increases from `2 × BlockInterval` to a range of `[2N, 3N-1] × BlockInterval` depending on block position within the voting cycle (see Section 7).
+Finality latency changes from `2·BlockInterval` to `N·BI + (2·OWD + T_import)` for voting blocks and `(2N - j)·BI + (2·OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration, average finality rises to ~1115ms under saturated load (vs. today's 900ms) in exchange for 1.8× block rate and near-100% CPU utilization; under light load it drops toward ~865ms.
 
 ## 10. License
 

--- a/BEPs/BEP-667.md
+++ b/BEPs/BEP-667.md
@@ -134,7 +134,7 @@ The above is a theoretical upper bound where `T_import` saturates the voting win
 - At `BI = 250ms, N = 2`, saturated finality is ~1115ms average — modestly higher than today's 900ms, in exchange for 1.8× block rate and ~100% CPU utilization (up from 47%).
 - At `BI = 100ms, N = 3`, finality drops to ~700ms *and* block rate increases 4.5×; such block intervals are unreachable without Vote Interval (BEP-126 requires `BI > 2 × OWD`).
 
-**Practical scenario.** In current workloads, `T_import` is well below the saturated bound. At the current 50M gas limit, typical `T_import ≈ 100ms`, giving `2 × OWD + T_import ≈ 340ms`:
+**Practical scenario.** In current workloads, `T_import` is well below the saturated bound. With a 50M gas limit, typical `T_import ≈ 100ms`, giving `2 × OWD + T_import ≈ 340ms`:
 
 | BlockInterval | N | 2 × OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
 |---------------|---|---------------------|--------------|-------------|---------|
@@ -152,7 +152,7 @@ Block production liveness is unaffected: non-voting blocks do not require Fast F
 
 This BEP is **not backward compatible**. It changes the Fast Finality voting and aggregation rules, requiring a hard fork with coordinated client upgrades across all validators and full nodes.
 
-Finality latency changes from `2 × BlockInterval` to `N × BI + (2 × OWD + T_import)` for voting blocks and `(2N - j) × BI + (2 × OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration with the current 50M gas limit (`T_import ≈ 100ms`), voting-block finality is ~840ms — faster than today's 900ms — with an average of ~965ms, while block rate increases 1.8×.
+Finality latency changes from `2 × BlockInterval` to `N × BI + (2 × OWD + T_import)` for voting blocks and `(2N - j) × BI + (2 × OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration with a 50M gas limit (`T_import ≈ 100ms`), voting-block finality is ~840ms — faster than today's 900ms — with an average of ~965ms, while block rate increases 1.8×.
 
 ## 10. License
 

--- a/BEPs/BEP-667.md
+++ b/BEPs/BEP-667.md
@@ -117,7 +117,7 @@ L(j) =  ⎨
          ⎩ (2N − j) × BI + (2 × OWD + T_import)     if 1 ≤ j < N  (non-voting block)
 ```
 
-where `2 × OWD + T_import` is the vote-gathering time, strictly less than `N × BI`. Without BEP-648, justification waits for header inclusion and finality becomes `2N × BI` for voting blocks and `(3N − j) × BI` for non-voting blocks.
+where `2 × OWD + T_import` is the vote-gathering time, strictly less than `N × BI`.
 
 With `OWD ≈ 120ms`:
 
@@ -128,7 +128,7 @@ With `OWD ≈ 120ms`:
 | 250ms         | 2 | 100ms (50M gas)   | 840ms        | 1090ms      | 965ms   |
 | 100ms         | 3 | 60ms (saturated)  | 600ms        | 800ms       | 700ms   |
 
-With a 50M gas limit (`T_import ≈ 100ms`), voting-block finality at `N = 2, BI = 250ms` is 840ms — faster than today's 900ms — while block rate increases 1.8×. Under saturated load, average finality rises to ~1115ms, a trade-off for near-100% CPU utilization. At `BI = 100ms, N = 3`, finality improves to ~700ms at 4.5× block rate; such block intervals are only reachable via Vote Interval.
+Even with throughput nearly doubling to ~200M gas/s (`N = 2, BI = 250ms`, 50M gas limit, `T_import ≈ 100ms`), average finality remains **965ms — still sub-second** (vs. today's 900ms at ~122M gas/s).
 
 ## 8. Security
 

--- a/BEPs/BEP-667.md
+++ b/BEPs/BEP-667.md
@@ -109,9 +109,7 @@ From `N × BlockInterval > 2 × OWD + T_import`, the maximum T_import is `N × B
 
 ## 7. Finality Analysis
 
-Vote Interval applies the BEP-126 justify/finalize rules — refined by [BEP-648](./BEP-648.md) — to the voting block subsequence. A non-voting block is finalized together with the next voting block.
-
-Let `j = blockNumber mod N` be a block's position within the voting cycle. By Section 2's core constraint, ⅔+ attestation is gathered within `2 × OWD + T_import < N × BI` after a voting block is produced. A voting block V[k] is finalized once V[k+1] is justified — one further voting interval plus another vote-gathering round:
+Vote Interval applies the BEP-126 justify/finalize rules — refined by [BEP-648](./BEP-648.md) — to the voting block subsequence. Let `j = blockNumber mod N`. A voting block V[k] is finalized once both V[k] and V[k+1] are justified; a non-voting block is finalized together with the next voting block:
 
 ```
          ⎧ N × BI + (2 × OWD + T_import)            if j = 0  (voting block)
@@ -119,28 +117,18 @@ L(j) =  ⎨
          ⎩ (2N − j) × BI + (2 × OWD + T_import)     if 1 ≤ j < N  (non-voting block)
 ```
 
-Without BEP-648, justification would wait for attestation inclusion in the next voting block's header and finality would be `2N × BI` / `(3N − j) × BI` respectively.
+where `2 × OWD + T_import` is the vote-gathering time, strictly less than `N × BI`. Without BEP-648, justification waits for header inclusion and finality becomes `2N × BI` for voting blocks and `(3N − j) × BI` for non-voting blocks.
 
-**Numerical comparison.** With `OWD ≈ 120ms` and `T_import` sized to saturate the voting window (Section 6):
+With `OWD ≈ 120ms`:
 
-| BlockInterval | N | T_import | 2 × OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
-|---------------|---|----------|--------------------|--------------|-------------|---------|
-| 450ms         | 1 | 210ms    | 450ms              | 900ms        | —           | 900ms   |
-| 250ms         | 2 | 250ms    | 490ms              | 990ms        | 1240ms      | 1115ms  |
-| 100ms         | 3 | 60ms     | 300ms              | 600ms        | 800ms       | 700ms   |
+| BlockInterval | N | T_import          | Voting (j=0) | Worst (j=1) | Average |
+|---------------|---|-------------------|--------------|-------------|---------|
+| 450ms (today) | 1 | 210ms             | 900ms        | —           | 900ms   |
+| 250ms         | 2 | 250ms (saturated) | 990ms        | 1240ms      | 1115ms  |
+| 250ms         | 2 | 100ms (50M gas)   | 840ms        | 1090ms      | 965ms   |
+| 100ms         | 3 | 60ms (saturated)  | 600ms        | 800ms       | 700ms   |
 
-The above is a theoretical upper bound where `T_import` saturates the voting window. Vote Interval structurally trades finality latency for block throughput and for feasibility at block intervals below `2 × OWD`:
-
-- At `BI = 250ms, N = 2`, saturated finality is ~1115ms average — modestly higher than today's 900ms, in exchange for 1.8× block rate and ~100% CPU utilization (up from 47%).
-- At `BI = 100ms, N = 3`, finality drops to ~700ms *and* block rate increases 4.5×; such block intervals are unreachable without Vote Interval (BEP-126 requires `BI > 2 × OWD`).
-
-**Practical scenario.** In current workloads, `T_import` is well below the saturated bound. With a 50M gas limit, typical `T_import ≈ 100ms`, giving `2 × OWD + T_import ≈ 340ms`:
-
-| BlockInterval | N | 2 × OWD + T_import | Voting (j=0) | Worst (j=1) | Average |
-|---------------|---|---------------------|--------------|-------------|---------|
-| 250ms         | 2 | 340ms               | 840ms        | 1090ms      | 965ms   |
-
-Voting-block finality (840ms) is faster than today's 900ms under `N = 1, BI = 450ms`, while block rate increases 1.8×.
+With a 50M gas limit (`T_import ≈ 100ms`), voting-block finality at `N = 2, BI = 250ms` is 840ms — faster than today's 900ms — while block rate increases 1.8×. Under saturated load, average finality rises to ~1115ms, a trade-off for near-100% CPU utilization. At `BI = 100ms, N = 3`, finality improves to ~700ms at 4.5× block rate; such block intervals are only reachable via Vote Interval.
 
 ## 8. Security
 
@@ -152,7 +140,7 @@ Block production liveness is unaffected: non-voting blocks do not require Fast F
 
 This BEP is **not backward compatible**. It changes the Fast Finality voting and aggregation rules, requiring a hard fork with coordinated client upgrades across all validators and full nodes.
 
-Finality latency changes from `2 × BlockInterval` to `N × BI + (2 × OWD + T_import)` for voting blocks and `(2N - j) × BI + (2 × OWD + T_import)` for non-voting blocks at position `j` (see Section 7). At the initial `N = 2, BI = 250ms` configuration with a 50M gas limit (`T_import ≈ 100ms`), voting-block finality is ~840ms — faster than today's 900ms — with an average of ~965ms, while block rate increases 1.8×.
+Finality latency changes from `2 × BlockInterval` to `N × BI + (2 × OWD + T_import)` for voting blocks and `(2N - j) × BI + (2 × OWD + T_import)` for non-voting blocks at position `j` .
 
 ## 10. License
 


### PR DESCRIPTION
 Finality was computed under BEP-126's header-based justification, inflating L to 2N·BI / (3N-j)·BI and giving 1000-1250ms at N=2/BI=250 (worse than today's 900ms). Apply BEP-648's rule on the voting block subsequence so L = N·BI + (2·OWD + T_import) / (2N-j)·BI + (2·OWD + T_import), fix table arithmetic, and state the throughput-vs-latency trade-off plainly.