### PR TITLE
BEP-695: Staking and Governance Security Hardening

### DIFF
--- a/BEPs/BEP-695.md
+++ b/BEPs/BEP-695.md
@@ -1,0 +1,53 @@
+<pre>
+  BEP: 695
+  Title: Staking and Governance Security Hardening
+  Status: Draft
+  Type: Standards
+  Created: 2026-06-09
+</pre>
+
+# BEP-695: Staking and Governance Security Hardening
+
+- [BEP-695: Staking and Governance Security Hardening](#bep-695-staking-and-governance-security-hardening)
+  - [1. Summary](#1-summary)
+  - [2. Motivation](#2-motivation)
+  - [3. Specification](#3-specification)
+    - [3.1 Revoke Validator-Admin Authority from Rotated Consensus Keys](#31-revoke-validator-admin-authority-from-rotated-consensus-keys)
+    - [3.2 Propagate Slash Eviction After Consensus Key Rotation](#32-propagate-slash-eviction-after-consensus-key-rotation)
+    - [3.3 Reject Blacklisted Voters on Signature-Based Governance Votes](#33-reject-blacklisted-voters-on-signature-based-governance-votes)
+  - [4. Backward Compatibility](#4-backward-compatibility)
+  - [5. License](#5-license)
+
+## 1. Summary
+
+This BEP bundles three security-hardening measures for the BSC system contracts: two tighten authorization and slash-eviction handling around validator consensus key rotation (`StakeHub` and `BSCValidatorSet`), and one strengthens blacklist enforcement on signature-based governance voting (`BSCGovernor`).
+
+## 2. Motivation
+
+Each measure closes a gap where stale state or an incomplete check led to an unsafe outcome:
+
+1. A rotated (old) consensus address could still authorize validator-admin actions.
+2. Slashing a validator that had rotated its consensus key did not promptly remove it from the active mining set.
+3. Blacklist enforcement on governance voting did not cover the signature-based voting paths.
+
+## 3. Specification
+
+### 3.1 Revoke Validator-Admin Authority from Rotated Consensus Keys
+
+`StakeHub` resolves a validator operator from the calling consensus address when authorizing validator-admin actions. This resolution now additionally requires the calling address to be the validator's current (non-expired) consensus key. The post-rotation (old) consensus address is intentionally retained in the mapping for slash and reward resolution, but it no longer resolves to the operator for admin actions.
+
+### 3.2 Propagate Slash Eviction After Consensus Key Rotation
+
+`StakeHub.doubleSignSlash` and `StakeHub.maliciousVoteSlash` now call `BSCValidatorSet.felony` with the validator's current consensus key, immediately after jailing. `BSCValidatorSet.felony` is specified as idempotent: invoking it with an address that is not in the active validator set (`currentValidatorSetMap`) returns without any state change. The existing `SlashIndicator`-driven eviction, which uses the pre-rotation consensus key, is retained. The two evictions are complementary and together remove the validator from the active set whether or not `BSCValidatorSet` has synced the rotated key.
+
+### 3.3 Reject Blacklisted Voters on Signature-Based Governance Votes
+
+`BSCGovernor`'s blacklist check previously applied only to the transaction sender. `BSCGovernor._castVote` now additionally reverts with `InBlackList` when the recovered voter `account` is blacklisted. This extends blacklist enforcement to the signature-based voting paths (`castVoteBySig` and `castVoteWithReasonAndParamsBySig`), where the sender is a relayer distinct from the voter. Direct voting, where the sender and voter are the same account, is unchanged.
+
+## 4. Backward Compatibility
+
+All three changes will be activated in the upcoming Pasteur hardfork. They only tighten enforcement and do not change any ABI, storage layout, or cross-chain message format, so compliant flows are expected to continue working unchanged.
+
+## 5. License
+  
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Here is the list of subjects of BEPs:
 | [BEP-675](./BEPs/BEP-675.md) | Builder-Proposed Block with Validator Blind Signing | Standards | Draft |
 | [BEP-677](./BEPs/BEP-677.md) | Implement EIP-8056 Scaled UI Amount | Standards | Draft |
 | [BEP-682](./BEPs/BEP-682.md) | Reject Duplicate Validators in CometBFT Light Block Validation | Standards | Draft |
+| [BEP-695](./BEPs/BEP-695.md) | Staking and Governance Security Hardening | Standards | Draft |
 
 # BAPs
 BAP (BNB Application Proposal) defines standards for application layer interactions on BNB Chain. Unlike BEPs which govern core protocol changes, BAPs focus on establishing conventions and interfaces for how applications communicate and interact with each other within the BNB Chain ecosystem.


### PR DESCRIPTION
Consolidate three bsc-genesis-contract hardening changes into one BEP:
- StakeHub: revoke validator-admin authority from rotated consensus keys (#659)
- StakeHub/BSCValidatorSet: propagate slash eviction after key rotation (#664)
- BSCGovernor: reject blacklisted voters on signature-based votes (#667)