### PR TITLE
BEP-696: Repurpose Unused Block Header Fields for Metadata

### DIFF
--- a/BEPs/BEP-696.md
+++ b/BEPs/BEP-696.md
@@ -1,0 +1,78 @@
+<pre>
+  BEP: 696
+  Title: Repurpose Unused Block Header Fields for Metadata
+  Status: Draft
+  Type: Standards
+  Created: 2026-06-11
+  Description: Allow BSC block producers to use currently unused header fields for producer metadata after a hard fork.
+</pre>
+
+# BEP-696: Repurpose Unused Block Header Fields for Metadata
+
+- [BEP-696: Repurpose Unused Block Header Fields for Metadata](#bep-696-repurpose-unused-block-header-fields-for-metadata)
+  - [1. Summary](#1-summary)
+  - [2. Motivation](#2-motivation)
+  - [3. Specification](#3-specification)
+    - [3.1 Current Behavior](#31-current-behavior)
+    - [3.2 Header Field Usage and Metadata Encoding](#32-header-field-usage-and-metadata-encoding)
+    - [3.3 Block Validity](#33-block-validity)
+  - [4. Backward Compatibility](#4-backward-compatibility)
+  - [5. License](#5-license)
+
+## 1. Summary
+
+This BEP repurposes two BSC block header fields that carry no information today, `UncleHash` and `ParentBeaconRoot`, as general-purpose metadata fields. Once this BEP is activated, block producers may write metadata, such as software or block-production pipeline version information, into these fields instead of keeping them pinned to constant values.
+
+## 2. Motivation
+
+Two 32-byte header fields are inherited from the Ethereum header format but carry no information on BSC:
+
+1. Parlia does not allow uncle blocks, so `UncleHash` is pinned to the empty-list hash in every block.
+2. BSC has no consensus-layer beacon chain, so `ParentBeaconRoot` is pinned to the zero hash and the EIP-4788 system call is never executed.
+
+Repurposing these two fields gives each block a home for producer metadata, such as the software or pipeline version that produced it, which is useful for rollout monitoring, debugging, and indexing. The metadata adds zero overhead — no new header field, no size increase, and no change to block encoding — and sits inside the sealed block header, covered by the producer's signature and directly readable by nodes, indexers, and monitoring systems.
+
+## 3. Specification
+
+### 3.1 Current Behavior
+
+Neither field carries information on BSC today; header verification pins both to constants:
+
+1. `UncleHash` is always the empty-list hash because Parlia does not allow uncle blocks.
+2. `ParentBeaconRoot` is nil before Bohr and the zero hash after Bohr. Since it is always zero when present, the EIP-4788 beacon-root system call is skipped on BSC.
+
+These constants do not affect EVM execution. This BEP relaxes the corresponding validation checks so the fields can carry producer metadata once activated.
+
+### 3.2 Header Field Usage and Metadata Encoding
+
+Starting from the activation of this BEP:
+
+1. Block producers may write producer metadata into `UncleHash`.
+2. Block producers may write producer metadata into `ParentBeaconRoot`.
+3. If a block producer does not write metadata, it SHOULD keep using the current default values: `EmptyUncleHash` for `UncleHash` and the zero hash for `ParentBeaconRoot`.
+
+The block header RLP layout and existing JSON-RPC field names remain unchanged: `sha3Uncles` and `parentBeaconBlockRoot` continue to expose the raw 32-byte values.
+
+This BEP reserves the two fields for producer metadata, such as version information, and does not mandate a specific encoding. A follow-up BEP or client release will define the concrete layout of the 32-byte values. Encodings MUST be deterministic and MUST NOT collide with the default values defined above.
+
+The metadata is claimed by the block producer and covered by the block seal, but its content is not verified by consensus. Consumers should treat it as informational metadata.
+
+### 3.3 Block Validity
+
+After this BEP is activated:
+
+1. Clients MUST accept any 32-byte value in `UncleHash` and `ParentBeaconRoot` when validating Parlia blocks. `ParentBeaconRoot` MUST remain present (non-nil).
+2. The uncle list in the block body MUST remain empty. Clients MUST verify this directly on the body, and MUST NOT derive the expected uncle list from `UncleHash`.
+3. `ParentBeaconRoot` MUST NOT trigger the EIP-4788 beacon root system call, regardless of its value. Neither field affects EVM execution.
+
+Before this BEP is activated, existing validation rules remain unchanged.
+
+## 4. Backward Compatibility
+
+This change requires a hard fork: nodes that do not upgrade will continue to enforce the constant values described in 3.1 and reject blocks that carry metadata in these fields.
+
+Since the header layout and field names are unchanged, existing tools continue to decode blocks, but tools that assume `sha3Uncles` is always the empty uncle hash or that `parentBeaconBlockRoot` is always zero should be updated. Until a concrete metadata encoding is deployed, the default values remain in use and observable chain data does not change at activation.
+
+## 5. License
+
+The content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Here is the list of subjects of BEPs:
 | [BEP-677](./BEPs/BEP-677.md) | Implement EIP-8056 Scaled UI Amount | Standards | Draft |
 | [BEP-682](./BEPs/BEP-682.md) | Reject Duplicate Validators in CometBFT Light Block Validation | Standards | Draft |
 | [BEP-695](./BEPs/BEP-695.md) | Staking and Governance Security Hardening | Standards | Draft |
+| [BEP-696](./BEPs/BEP-696.md) | Repurpose Unused Block Header Fields for Metadata | Standards | Draft |
 
 # BAPs
 BAP (BNB Application Proposal) defines standards for application layer interactions on BNB Chain. Unlike BEPs which govern core protocol changes, BAPs focus on establishing conventions and interfaces for how applications communicate and interact with each other within the BNB Chain ecosystem.


### PR DESCRIPTION
 bep-696: Allow BSC block producers to use currently unused header fields for producer metadata after a hard fork.