### PR TITLE
BEP-673: add BEP-675 integration note for Pasteur hardfork

### DIFF
--- a/BEPs/BEP-673.md
+++ b/BEPs/BEP-673.md
@@ -36,6 +36,7 @@ The Pasteur network upgrade comprises a total of 3 BSC only BEPs.
 
 #### BEPs without hard fork
 * [BEP-675](./BEP-675.md) : Builder-Proposed Block with Validator Blind Signing
+  * To give builders sufficient time for integration, the `SendBidBlock` path on the validator side is enabled only after the Pasteur hard fork activates, and the activation is controlled via RPC interfaces.
 
 ## 3. Security Considerations
 


### PR DESCRIPTION
Clarify that the SendBidBlock path on the validator side is enabled only after the Pasteur hard fork activates and is controlled via RPC interfaces, to give builders sufficient time for integration.