### PR TITLE
BEP-713: add Post-Quantum Cryptography Migration Roadmap for BSC

### DIFF
--- a/BEPs/BEP-713.md
+++ b/BEPs/BEP-713.md
@@ -1,0 +1,135 @@
+```
+BEP: 713
+Title: Post-Quantum Cryptography Migration Roadmap for BSC
+Status: Draft
+Type: Information
+Created: 2026-09-10
+Description(optional): BSC-specific phased roadmap for post-quantum migration. Inventories BSC's quantum-vulnerable components and organises the work into four phases, each realised by a series of companion Standards BEPs.
+```
+
+# BEP-713: Post-Quantum Cryptography Migration Roadmap for BSC
+
+## 1. Summary
+
+This BEP is the **BSC-specific** post-quantum migration roadmap, a companion to the family-level umbrella [BEP-707](./BEP-707.md). It inventories BSC's quantum-vulnerable cryptography and organises the migration into four phases, each realised by a **series of companion Standards BEPs**.
+
+It is an Information BEP and specifies no algorithms, parameters, or wire formats — those belong to the per-phase Standards BEPs it indexes. [BEP-708](./BEP-708.md) is the first of them.
+
+## 2. BSC's Quantum-Vulnerable Surface
+
+| # | Component | Primitive | Consequence of a break | Phase |
+| --- | --- | --- | --- | --- |
+| 1 | RLPx session key agreement | secp256k1 ECDH | Recorded traffic decrypted retroactively | 1 |
+| 2 | discv4 / discv5, ENR signing | secp256k1 | Forged node records | 1 |
+| 3 | Operator transport (RPC/TLS, sentry links) | Classical TLS key exchange | Recorded operator traffic decrypted retroactively | 1 |
+| 4 | Account and transaction signatures | ECDSA (secp256k1) | Private key recovered from an exposed public key; assets stolen | 2 |
+| 5 | Node identity (enode key) | secp256k1 | Node impersonation | 2 |
+| 6 | Validator vote keys | BLS12-381 | Forged individual votes | 2 |
+| 7 | Fast-finality vote aggregation ([BEP-126](./BEP126.md)) | BLS12-381 aggregate signatures | Forged finality | 3 |
+| 8 | Blob commitments ([BEP-336](./BEP-336.md)) | KZG (BLS12-381) | Forged data commitments | 3 |
+| 9 | Pairing precompiles `0x06`–`0x08` | BN254 | On-chain verification forgeable | 3 |
+| 10 | EIP-2537 precompiles ([BEP-439](./BEP-439.md)) | BLS12-381 | Same, for contracts built on them | 3 |
+| 11 | Cross-chain light-client and relayer verification ([BEP-221](./BEP221.md)) | ed25519 + BLS12-381 | Forged cross-chain messages | 2 / 3 |
+| — | Block hashes, Merkle-Patricia proofs, Keccak | Keccak-256, SHA-2 | Grover only — strength halved, recoverable by output length | none |
+
+Rows 1–3 are the only ones where **delay itself causes permanent loss**: recorded ciphertext can be decrypted after Q-Day, while every other row requires the quantum computer to exist at the moment of attack. The final row is why this is bounded work rather than a rewrite — BSC's hashing, data structures, and proofs survive, so the migration is confined to public-key cryptography.
+
+This table is intended as the authoritative inventory; each per-phase BEP is expected to account for the rows assigned to it.
+
+## 3. Phases
+
+Phase numbering is inherited from BEP-707. Phase 0 is added because agility must exist before the first algorithm swap, not after it.
+
+### Phase 0 — Crypto-agility foundations
+
+**No hardfork. No user-visible change.** BSC encodes algorithm choice implicitly today — a 65-byte signature field means secp256k1 because nothing else could be there. That must become an explicit algorithm identifier before anything is swapped, or every later phase pays for it. Companion BEPs cover the algorithm registry and versioned key/signature envelopes, and the library, conformance, and test-vector policy for consensus-critical cryptographic code.
+
+### Phase 1 — Transport and network layer
+
+**Highest priority. No hardfork. Ship first.** This is the only phase addressing exposure that accrues today, and the cheapest: transport is not consensus-critical, so it ships through client releases with no state-transition impact, no address change, and no user action. Companion BEPs cover the RLPx hybrid key exchange ([BEP-708](./BEP-708.md)), discovery and ENR, and operator-facing transport.
+
+### Phase 2 — Signatures and accounts
+
+**Hardfork required. Largest asset-security surface.** Because addresses are reused, every address that has sent a transaction has published its public key. Migration is opt-in and address-preserving: an account binds a post-quantum key using its existing ECDSA key, and can later require it. Companion BEPs cover post-quantum signature verification and scheme selection, account key binding, the transaction type, validator vote and node identity keys, staking and system-contract integration, wallet and keystore standards, and — separately and much later — the ECDSA wind-down.
+
+Scheme selection is a first-class decision on BSC rather than a default, because signatures grow substantially:
+
+| Scheme | Signature | vs. secp256k1 |
+| --- | --- | --- |
+| ECDSA (secp256k1) | 65 B | 1× |
+| ML-DSA-44 (FIPS 204) | 2 420 B | ~37× |
+| SLH-DSA-128s (FIPS 205) | 7 856 B | ~121× |
+| FN-DSA-512 / Falcon-512 | ~666 B | ~10× |
+
+At a **0.75 s block interval** this is pressure on block propagation, mempool bandwidth, state growth, and the fast-finality vote deadline — a liveness concern, not only a gas cost. It is why Phase 2 is gradual rather than a flag day.
+
+### Phase 3 — Pairing-based cryptography
+
+**Hardfork required. Research-gated, no fixed activation date.** The pairing family shares one vulnerability and migrates together. Companion BEPs cover fast-finality vote aggregation, blob and DA commitments, pairing precompile succession, and cross-chain verification.
+
+Post-quantum aggregate signatures remain an industry-wide open problem, so the aggregation component is explicitly **"start when research-ready"**. The constraint on BSC is sharp: a replacement must aggregate a full validator set's votes and verify within the vote deadline at a 0.75 s block interval. The other three components are schedulable and should not be held behind it. Until then, the Phase 0 agility work is what keeps these components swappable.
+
+## 4. BEP Series Index
+
+| Phase | BEP | Scope | Hardfork | Status |
+| --- | --- | --- | --- | --- |
+| 0 | TBD | Algorithm registry and versioned envelopes | No | Not started |
+| 0 | TBD | Library, dependency, and conformance policy | No | Not started |
+| 1 | [BEP-708](./BEP-708.md) | RLPx v5 hybrid key exchange | No | Draft |
+| 1 | TBD | Discovery / ENR | No | Not started |
+| 1 | TBD | Operator transport | No | Not started |
+| 2 | TBD | PQ signature verification and scheme selection | Yes | Not started |
+| 2 | TBD | Address-preserving account key binding | Yes | Not started |
+| 2 | TBD | Post-quantum transaction type | Yes | Not started |
+| 2 | TBD | Validator vote and node identity keys | Yes | Not started |
+| 2 | TBD | Staking and system-contract integration | Yes | Not started |
+| 2 | TBD | Wallet, keystore, and tooling standards | No | Not started |
+| 2 | TBD | ECDSA wind-down policy | Yes | Not started |
+| 3 | TBD | Post-quantum fast-finality aggregation | Yes | Research-gated |
+| 3 | TBD | Hash-based blob / DA commitments | Yes | Not started |
+| 3 | TBD | Pairing precompile succession | Yes | Not started |
+| 3 | TBD | Cross-chain verification successor | Yes | Not started |
+
+`TBD` entries are replaced by BEP numbers as they are assigned; per [BEP-1](./BEP1.md) the pull request number becomes the BEP number.
+
+## 5. Sequencing
+
+- **Phase 0 precedes the first algorithm swap** in any phase, but can be drafted in parallel with Phase 1.
+- **Phase 1 is independent of Phases 2 and 3** and must not be scheduled behind them. It needs no hardfork, and it is the only phase whose delay causes irreversible loss.
+- **Within Phase 2, verification ships before** the transaction type and account binding that depend on it.
+- **Phase 3's aggregation component is not schedulable**; the other three are and should proceed.
+
+Phases 2 and 3 affect consensus and follow the standard BNB Chain governance process, including a governance vote where required. Phase 1 does not.
+
+## 6. Rationale
+
+**Why a series per phase.** Each phase spans components with different reviewers, risk profiles, and readiness dates. One BEP per phase would move at the speed of its slowest part — the transaction type would wait on wallet standards, and the whole pairing family would wait on unresolved research. Splitting them lets each land when ready while this roadmap keeps them coherent.
+
+**Why the order is not by severity.** Phase 2 protects the most value, yet Phase 1 goes first. Sequencing follows threat shelf-life and solution maturity: Phase 1's exposure accrues now and its solution is already deployed in mainstream TLS, while Phase 2's threat requires a quantum computer at attack time. Doing the retroactive one first costs Phase 2 nothing, since neither depends on the other.
+
+**Why opt-in in Phase 2.** A mandatory migration across BSC's account base with a ~37× signature expansion would be simultaneously a UX and a capacity event. Opt-in binding lets exposed high-value accounts migrate first and keeps the wind-down an explicit governance decision rather than an implicit deadline.
+
+## 7. Backward Compatibility
+
+This BEP introduces no consensus, format, or API change. Per-BEP compatibility analysis lives in the companion Standards BEPs.
+
+One roadmap-level rule constrains them all: every phase deploys post-quantum cryptography **alongside** the classical primitive, and no BEP removes a classical path in the same change that introduces its replacement. Retirement is always a separate, later BEP with its own activation, so an unupgraded node, wallet, or contract keeps working across any single activation in this series.
+
+Non-upgradeable contracts with hard-coded vulnerable cryptography are the unavoidable exception; no chain-level change fixes them retroactively.
+
+## 8. References
+
+* [BEP-707: Post-Quantum Cryptography Migration Roadmap for BNB Chain](./BEP-707.md) — umbrella
+* [BEP-708: Post-Quantum Hybrid Key Exchange for the BSC P2P Transport (RLPx v5)](./BEP-708.md) — Phase 1
+* [BEP-126: Fast Finality Mechanism](./BEP126.md)
+* [BEP-336: Implement EIP-4844: Shard Blob Transactions](./BEP-336.md)
+* [BEP-439: Implement EIP-2537: Precompile for BLS12-381 curve operations](./BEP-439.md)
+* [BEP-221: CometBFT Light Block Validation](./BEP221.md)
+* [BEP-1: BEP Purpose and Guidelines](./BEP1.md)
+* [FIPS 203 (ML-KEM)](https://csrc.nist.gov/pubs/fips/203/final), [FIPS 204 (ML-DSA)](https://csrc.nist.gov/pubs/fips/204/final), [FIPS 205 (SLH-DSA)](https://csrc.nist.gov/pubs/fips/205/final)
+
+> BEP-707 and BEP-708 are proposed but not yet merged, so those two links resolve only once they land.
+
+## 9. License
+
+All the content is licensed under [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/BEPs/BEP-713.md
+++ b/BEPs/BEP-713.md
@@ -61,13 +61,13 @@ Scheme selection is a first-class decision on BSC rather than a default, because
 | SLH-DSA-128s (FIPS 205) | 7 856 B | ~121× |
 | FN-DSA-512 / Falcon-512 | ~666 B | ~10× |
 
-At a **0.75 s block interval** this is pressure on block propagation, mempool bandwidth, state growth, and the fast-finality vote deadline — a liveness concern, not only a gas cost. It is why Phase 2 is gradual rather than a flag day.
+At a **0.45 s block interval** this is pressure on block propagation, mempool bandwidth, state growth, and the fast-finality vote deadline — a liveness concern, not only a gas cost. It is why Phase 2 is gradual rather than a flag day.
 
 ### Phase 3 — Pairing-based cryptography
 
 **Hardfork required. Research-gated, no fixed activation date.** The pairing family shares one vulnerability and migrates together. Companion BEPs cover fast-finality vote aggregation, blob and DA commitments, pairing precompile succession, and cross-chain verification.
 
-Post-quantum aggregate signatures remain an industry-wide open problem, so the aggregation component is explicitly **"start when research-ready"**. The constraint on BSC is sharp: a replacement must aggregate a full validator set's votes and verify within the vote deadline at a 0.75 s block interval. The other three components are schedulable and should not be held behind it. Until then, the Phase 0 agility work is what keeps these components swappable.
+Post-quantum aggregate signatures remain an industry-wide open problem, so the aggregation component is explicitly **"start when research-ready"**. The constraint on BSC is sharp: a replacement must aggregate a full validator set's votes and verify within the vote deadline at a 0.45 s block interval. The other three components are schedulable and should not be held behind it. Until then, the Phase 0 agility work is what keeps these components swappable.
 
 ## 4. BEP Series Index
 


### PR DESCRIPTION
BEP-713 is the family-level umbrella; this BEP takes BSC's slice of it and makes it executable. BSC carries the entire quantum-vulnerable surface of the family and gates opBNB's Phase 2, so its sequencing is a shared concern worth specifying.

- Authoritative inventory of BSC's 11 vulnerable components, mapped to phases, plus the hash-based structures that survive
- Four phases: Phase 0 crypto-agility foundations (added, since BSC encodes algorithm choice implicitly today), Phase 1 transport (no hardfork), Phase 2 signatures/accounts, Phase 3 pairing family
- Each phase decomposed into a series of companion Standards BEPs, with a status index; BEP-708 is the first Phase 1 entry
- Sequencing rules, hardfork gating, and the ~37x signature expansion against BSC's 0.75s block interval as the constraint shaping Phase 2

Type: Information. No algorithms or wire formats are specified here.